### PR TITLE
Add monthly walkshed refresh workflow + bake pipeline (issue #5)

### DIFF
--- a/.github/workflows/refresh-walksheds.yml
+++ b/.github/workflows/refresh-walksheds.yml
@@ -1,0 +1,99 @@
+name: Refresh walksheds
+
+on:
+  schedule:
+    # 1st of the month, 08:00 UTC (~01:00 PT)
+    - cron: "0 8 1 * *"
+  workflow_dispatch:
+
+concurrency:
+  group: walkshed-refresh
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    name: Refresh + bake walksheds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Python deps
+        run: pip install pytest httpx
+
+      - name: Refresh SDOT raw data and rebuild station index
+        run: uv run data/refresh.py
+
+      - name: Compare station index against live SDOT
+        id: compare
+        continue-on-error: true
+        run: python data/compare_station_index.py
+
+      - name: Bake Mapbox isochrones
+        env:
+          MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+        run: python data/bake_walksheds.py
+
+      - name: Run data tests
+        run: cd data && pytest -v
+
+      - name: Frontend smoke build
+        env:
+          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+        run: |
+          npm ci
+          npm run build
+
+      - name: Open pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: data/refresh-walksheds-${{ github.run_id }}
+          base: main
+          title: "data: refresh walksheds"
+          commit-message: "data: refresh walksheds"
+          body: |
+            Automated walkshed refresh.
+
+            - SDOT raw data: re-downloaded
+            - Station index drift status: **${{ steps.compare.outcome }}**
+            - Mapbox isochrones: re-baked
+
+            If drift status is `failure`, see the workflow run summary for the
+            drift report and update `data/process.py` (`NAME_MAP` /
+            `MISSING_STATIONS` / line orders) before merging.
+
+            Workflow: [`refresh-walksheds.yml`](.github/workflows/refresh-walksheds.yml)
+          labels: |
+            data-refresh
+          add-paths: |
+            data/raw/light-rail-stations.geojson
+            data/raw/light-rail-alignment.geojson
+            data/station-index.json
+            public/all-stations.geojson
+            public/line1-alignment.geojson
+            public/line2-alignment.geojson
+            public/walksheds.geojson
+
+      - name: Add drift-detected label
+        if: steps.compare.outcome == 'failure' && steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "${{ steps.cpr.outputs.pull-request-number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label drift-detected

--- a/data/bake_walksheds.py
+++ b/data/bake_walksheds.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx"]
+# ///
+"""Bake walking-distance isochrones for every station × duration.
+
+Reads data/station-index.json, calls the Mapbox Isochrone API once per
+(station, minutes) pair, and writes a single consolidated
+public/walksheds.geojson keyed by "{lines}-{stopCode}-{minutes}".
+
+Coordinates are rounded to 6 decimal places (~11 cm precision) before
+serialization to keep diffs minimal between bakes.
+
+Usage: MAPBOX_ACCESS_TOKEN=... python data/bake_walksheds.py [--dry-run]
+"""
+
+import datetime as dt
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+ROOT = Path(__file__).resolve().parent.parent
+INDEX_PATH = ROOT / "data" / "station-index.json"
+OUTPUT_PATH = ROOT / "public" / "walksheds.geojson"
+
+ISOCHRONE_URL = "https://api.mapbox.com/isochrone/v1/mapbox/walking/{lng},{lat}"
+DEFAULT_OPTIONS = (5, 10, 15)
+DEFAULT_DELAY_S = 0.05
+TIMEOUT_S = 30
+COORD_PRECISION = 6
+BAKE_VERSION = 1
+
+KEY_RE = re.compile(r"^[12](,[12])?-\d+-\d+$")
+
+
+def make_key(lines: str, stop_code: int, minutes: int) -> str:
+    return f"{lines}-{stop_code}-{minutes}"
+
+
+def _round_coords(obj):
+    """Recursively round all numeric coordinates in a GeoJSON-ish structure."""
+    if isinstance(obj, list):
+        if obj and all(isinstance(x, (int, float)) for x in obj):
+            return [round(float(x), COORD_PRECISION) if isinstance(x, float) else x for x in obj]
+        return [_round_coords(x) for x in obj]
+    if isinstance(obj, dict):
+        return {k: _round_coords(v) for k, v in obj.items()}
+    return obj
+
+
+def bake_one(client: httpx.Client, lng: float, lat: float, minutes: int, token: str) -> dict:
+    """Fetch one isochrone polygon. Raises on non-200."""
+    url = ISOCHRONE_URL.format(lng=lng, lat=lat)
+    resp = client.get(
+        url,
+        params={
+            "contours_minutes": minutes,
+            "polygons": "true",
+            "access_token": token,
+        },
+        timeout=TIMEOUT_S,
+    )
+    resp.raise_for_status()
+    fc = resp.json()
+    if fc.get("type") != "FeatureCollection":
+        raise ValueError(f"Expected FeatureCollection, got: {fc.get('type')}")
+    return _round_coords(fc)
+
+
+def bake(
+    index: dict,
+    token: str,
+    delay: float = DEFAULT_DELAY_S,
+    options: tuple[int, ...] = DEFAULT_OPTIONS,
+    client: httpx.Client | None = None,
+) -> dict:
+    """Bake every (station, minutes) combo. Returns the full output dict."""
+    walksheds: dict[str, dict] = {}
+    own_client = client is None
+    if own_client:
+        client = httpx.Client()
+    try:
+        first = True
+        for station in index["stations"]:
+            for minutes in options:
+                if not first:
+                    time.sleep(delay)
+                first = False
+                key = make_key(station["lines"], station["stopCode"], minutes)
+                if not KEY_RE.match(key):
+                    raise ValueError(f"Bad key: {key}")
+                fc = bake_one(client, station["lng"], station["lat"], minutes, token)
+                walksheds[key] = fc
+                print(f"  baked {key} ({station['name']})")
+    finally:
+        if own_client:
+            client.close()
+
+    return {
+        "version": BAKE_VERSION,
+        "generated": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "walksheds": walksheds,
+    }
+
+
+def write_atomic(output_path: Path, data: dict) -> None:
+    """Write a JSON file atomically (.tmp then rename)."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = output_path.with_suffix(output_path.suffix + ".tmp")
+    with open(tmp, "w") as f:
+        json.dump(data, f, sort_keys=True)
+    tmp.replace(output_path)
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+    token = os.environ.get("MAPBOX_ACCESS_TOKEN") or os.environ.get("VITE_MAPBOX_ACCESS_TOKEN")
+    if not token:
+        sys.exit("Error: MAPBOX_ACCESS_TOKEN env var not set")
+
+    with open(INDEX_PATH) as f:
+        index = json.load(f)
+
+    if dry_run:
+        index = {**index, "stations": index["stations"][:1]}
+        print(f"Dry run — baking only {index['stations'][0]['name']}")
+
+    print(f"Baking {len(index['stations'])} stations × {len(DEFAULT_OPTIONS)} durations...")
+    output = bake(index, token=token)
+
+    # Sanity check: token must not appear in serialized output.
+    serialized = json.dumps(output)
+    if token in serialized:
+        sys.exit("Error: Mapbox token leaked into bake output, aborting write")
+
+    if dry_run:
+        print(f"\nDry run — skipping write. Baked {len(output['walksheds'])} entries.")
+        return
+
+    write_atomic(OUTPUT_PATH, output)
+    print(f"\nWrote {OUTPUT_PATH} with {len(output['walksheds'])} walksheds")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/build_station_index.py
+++ b/data/build_station_index.py
@@ -1,0 +1,53 @@
+"""Build a canonical station index from public/all-stations.geojson.
+
+The station index is the deliberate, human-reviewable list of stations that
+the walkshed bake step iterates over and the drift detector compares against
+the live SDOT feed. It is derived from the processed all-stations GeoJSON.
+
+Run from project root: python3 data/build_station_index.py
+"""
+
+import json
+import os
+from typing import Any
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+INPUT = os.path.join(ROOT, "public", "all-stations.geojson")
+OUTPUT = os.path.join(ROOT, "data", "station-index.json")
+
+INDEX_VERSION = 1
+
+
+def build(stations_geojson: dict) -> dict:
+    """Pure function: GeoJSON FeatureCollection -> station index dict.
+
+    Output is deterministic — stations are sorted by (lines, stopCode) so the
+    JSON file diffs cleanly.
+    """
+    stations: list[dict[str, Any]] = []
+    for feat in stations_geojson["features"]:
+        props = feat["properties"]
+        lng, lat = feat["geometry"]["coordinates"]
+        stations.append({
+            "name": props["name"],
+            "lines": props["lines"],
+            "stopCode": props["stopCode"],
+            "lng": lng,
+            "lat": lat,
+        })
+    stations.sort(key=lambda s: (s["lines"], s["stopCode"]))
+    return {"version": INDEX_VERSION, "stations": stations}
+
+
+def main():
+    with open(INPUT) as f:
+        stations_geojson = json.load(f)
+    index = build(stations_geojson)
+    with open(OUTPUT, "w") as f:
+        json.dump(index, f, indent=2, sort_keys=True)
+        f.write("\n")
+    print(f"Wrote {OUTPUT} with {len(index['stations'])} stations")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/compare_station_index.py
+++ b/data/compare_station_index.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx"]
+# ///
+"""Compare data/station-index.json against the live SDOT stations feed.
+
+Reports stations that have been added, removed, or moved beyond a tolerance.
+Exits non-zero on any drift so the calling workflow can label its output PR.
+
+Usage: python data/compare_station_index.py [--threshold 75]
+"""
+
+import json
+import math
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Allow `import refresh`/`import process` regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import refresh  # noqa: E402
+from process import MISSING_STATIONS, NAME_MAP  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+INDEX_PATH = ROOT / "data" / "station-index.json"
+
+DEFAULT_THRESHOLD_M = 75.0
+
+
+def haversine(lng1: float, lat1: float, lng2: float, lat2: float) -> float:
+    """Great-circle distance in meters."""
+    r = 6_371_000.0
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lng2 - lng1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))
+
+
+@dataclass
+class Drift:
+    name: str
+    distance_m: float
+
+
+@dataclass
+class Report:
+    added: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+    drifted: list[Drift] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not (self.added or self.removed or self.drifted)
+
+
+def load_index(path: Path = INDEX_PATH) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def fetch_live() -> dict:
+    data = refresh.fetch_geojson(refresh.STATIONS_URL)
+    refresh.validate_stations(data)
+    return data
+
+
+def _live_station_map(live: dict) -> dict[str, tuple[float, float]]:
+    """Map of live station name (post NAME_MAP normalization) -> (lng, lat).
+
+    Filters to existing/under-construction stations and excludes Tacoma Link
+    (matching the filter in process.py).
+    """
+    out: dict[str, tuple[float, float]] = {}
+    tacoma_kw = ("Commerce", "Theater District", "Convention Center",
+                 "Union Station", "Tacoma Dome", "South 25th")
+    for feat in live["features"]:
+        props = feat["properties"]
+        if props.get("STATUS") != "Existing / Under Construction":
+            continue
+        # process.py uses list(values())[2] for the name; mirror that here.
+        raw_name = list(props.values())[2] if len(props) > 2 else props.get("NAME", "")
+        if not raw_name or any(kw in raw_name for kw in tacoma_kw):
+            continue
+        name = NAME_MAP.get(raw_name, raw_name)
+        coords = feat["geometry"]["coordinates"]
+        out[name] = (coords[0], coords[1])
+    return out
+
+
+def compare(index: dict, live: dict, threshold_m: float = DEFAULT_THRESHOLD_M) -> Report:
+    """Diff a station index against a live SDOT GeoJSON FeatureCollection."""
+    index_by_name = {s["name"]: s for s in index["stations"]}
+    live_by_name = _live_station_map(live)
+    missing_names = {name for name, _, _ in MISSING_STATIONS}
+
+    report = Report()
+
+    # Stations live knows about that we don't.
+    for name in sorted(live_by_name.keys() - index_by_name.keys()):
+        report.added.append(name)
+
+    # Stations we have that live doesn't, ignoring known-missing.
+    for name in sorted(index_by_name.keys() - live_by_name.keys()):
+        if name in missing_names:
+            continue
+        report.removed.append(name)
+
+    # Coordinate drift on intersection (also skip MISSING_STATIONS — those
+    # carry approximate coords and aren't authoritative).
+    for name in sorted(index_by_name.keys() & live_by_name.keys()):
+        if name in missing_names:
+            continue
+        idx = index_by_name[name]
+        lng, lat = live_by_name[name]
+        d = haversine(idx["lng"], idx["lat"], lng, lat)
+        if d > threshold_m:
+            report.drifted.append(Drift(name=name, distance_m=d))
+
+    return report
+
+
+def format_summary(report: Report, threshold_m: float) -> str:
+    lines = ["# Station index drift report", ""]
+    if report.ok:
+        lines.append(f"OK — no drift detected (threshold {threshold_m:.0f} m).")
+        return "\n".join(lines) + "\n"
+
+    lines.append(f"Drift detected (threshold {threshold_m:.0f} m).")
+    lines.append("")
+    if report.added:
+        lines.append(f"## Added in live feed ({len(report.added)})")
+        for n in report.added:
+            lines.append(f"- {n}")
+        lines.append("")
+    if report.removed:
+        lines.append(f"## Missing from live feed ({len(report.removed)})")
+        for n in report.removed:
+            lines.append(f"- {n}")
+        lines.append("")
+    if report.drifted:
+        lines.append(f"## Coordinate drift ({len(report.drifted)})")
+        for d in report.drifted:
+            lines.append(f"- {d.name}: {d.distance_m:.0f} m")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    threshold = DEFAULT_THRESHOLD_M
+    if "--threshold" in sys.argv:
+        i = sys.argv.index("--threshold")
+        threshold = float(sys.argv[i + 1])
+
+    print("Loading station index...")
+    index = load_index()
+    print(f"  → {len(index['stations'])} stations")
+
+    print("Fetching live SDOT stations...")
+    live = fetch_live()
+    print(f"  → {len(live['features'])} features")
+
+    report = compare(index, live, threshold_m=threshold)
+    summary = format_summary(report, threshold)
+    print()
+    print(summary)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write(summary)
+
+    sys.exit(0 if report.ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/refresh.py
+++ b/data/refresh.py
@@ -87,7 +87,10 @@ def download(dry_run: bool = False) -> tuple[dict, dict]:
     print("\nProcessing...")
     subprocess.check_call([sys.executable, str(ROOT / "data" / "process.py")])
 
-    print("\nDone. Review changes with: git diff public/")
+    print("\nBuilding station index...")
+    subprocess.check_call([sys.executable, str(ROOT / "data" / "build_station_index.py")])
+
+    print("\nDone. Review changes with: git diff public/ data/station-index.json")
     return stations, alignment
 
 

--- a/data/station-index.json
+++ b/data/station-index.json
@@ -1,0 +1,271 @@
+{
+  "stations": [
+    {
+      "lat": 47.5911083518244,
+      "lines": "1",
+      "lng": -122.327171618272,
+      "name": "Stadium Station",
+      "stopCode": 54
+    },
+    {
+      "lat": 47.581074282053,
+      "lines": "1",
+      "lng": -122.327389774014,
+      "name": "SODO Station",
+      "stopCode": 55
+    },
+    {
+      "lat": 47.5793276863571,
+      "lines": "1",
+      "lng": -122.311533471218,
+      "name": "Beacon Hill Station",
+      "stopCode": 56
+    },
+    {
+      "lat": 47.5765501262846,
+      "lines": "1",
+      "lng": -122.297679104375,
+      "name": "Mount Baker Station",
+      "stopCode": 57
+    },
+    {
+      "lat": 47.5597334784311,
+      "lines": "1",
+      "lng": -122.292691648732,
+      "name": "Columbia City Station",
+      "stopCode": 58
+    },
+    {
+      "lat": 47.5379868480215,
+      "lines": "1",
+      "lng": -122.281562901357,
+      "name": "Othello Station",
+      "stopCode": 60
+    },
+    {
+      "lat": 47.5223936042706,
+      "lines": "1",
+      "lng": -122.279390550758,
+      "name": "Rainier Beach Station",
+      "stopCode": 61
+    },
+    {
+      "lat": 47.4640306108864,
+      "lines": "1",
+      "lng": -122.287995911829,
+      "name": "Tukwila International Blvd Station",
+      "stopCode": 63
+    },
+    {
+      "lat": 47.4453811664942,
+      "lines": "1",
+      "lng": -122.296898315866,
+      "name": "Airport / SeaTac Station",
+      "stopCode": 64
+    },
+    {
+      "lat": 47.4227026714562,
+      "lines": "1",
+      "lng": -122.29771402321,
+      "name": "Angle Lake Station",
+      "stopCode": 65
+    },
+    {
+      "lat": 47.411,
+      "lines": "1",
+      "lng": -122.2953,
+      "name": "Kent Des Moines Station",
+      "stopCode": 66
+    },
+    {
+      "lat": 47.394,
+      "lines": "1",
+      "lng": -122.293,
+      "name": "Star Lake Station",
+      "stopCode": 67
+    },
+    {
+      "lat": 47.317,
+      "lines": "1",
+      "lng": -122.312,
+      "name": "Federal Way Downtown Station",
+      "stopCode": 68
+    },
+    {
+      "lat": 47.8156,
+      "lines": "1,2",
+      "lng": -122.2948,
+      "name": "Lynnwood City Center Station",
+      "stopCode": 40
+    },
+    {
+      "lat": 47.785,
+      "lines": "1,2",
+      "lng": -122.3148,
+      "name": "Mountlake Terrace Station",
+      "stopCode": 41
+    },
+    {
+      "lat": 47.7641,
+      "lines": "1,2",
+      "lng": -122.3229,
+      "name": "Shoreline North/185th Station",
+      "stopCode": 42
+    },
+    {
+      "lat": 47.7361012121992,
+      "lines": "1,2",
+      "lng": -122.325233528668,
+      "name": "Shoreline South/148th Station",
+      "stopCode": 43
+    },
+    {
+      "lat": 47.7030278568312,
+      "lines": "1,2",
+      "lng": -122.328290001707,
+      "name": "Northgate Station",
+      "stopCode": 45
+    },
+    {
+      "lat": 47.6765945836052,
+      "lines": "1,2",
+      "lng": -122.315976128072,
+      "name": "Roosevelt Station",
+      "stopCode": 46
+    },
+    {
+      "lat": 47.6603010387388,
+      "lines": "1,2",
+      "lng": -122.314131795454,
+      "name": "U District Station",
+      "stopCode": 47
+    },
+    {
+      "lat": 47.6498150806149,
+      "lines": "1,2",
+      "lng": -122.303763015652,
+      "name": "University of Washington Station",
+      "stopCode": 48
+    },
+    {
+      "lat": 47.6190601473748,
+      "lines": "1,2",
+      "lng": -122.320194654226,
+      "name": "Capitol Hill Station",
+      "stopCode": 49
+    },
+    {
+      "lat": 47.6115721588528,
+      "lines": "1,2",
+      "lng": -122.336719986395,
+      "name": "Westlake Station",
+      "stopCode": 50
+    },
+    {
+      "lat": 47.6078102407675,
+      "lines": "1,2",
+      "lng": -122.336019831775,
+      "name": "Symphony Station",
+      "stopCode": 51
+    },
+    {
+      "lat": 47.6025601245898,
+      "lines": "1,2",
+      "lng": -122.33121602176,
+      "name": "Pioneer Square Station",
+      "stopCode": 52
+    },
+    {
+      "lat": 47.5983550239356,
+      "lines": "1,2",
+      "lng": -122.327992256932,
+      "name": "International District Station",
+      "stopCode": 53
+    },
+    {
+      "lat": 47.5902991386253,
+      "lines": "2",
+      "lng": -122.304508544173,
+      "name": "Judkins Park Station",
+      "stopCode": 54
+    },
+    {
+      "lat": 47.5881982178678,
+      "lines": "2",
+      "lng": -122.233231674682,
+      "name": "Mercer Island Station",
+      "stopCode": 55
+    },
+    {
+      "lat": 47.5865560021647,
+      "lines": "2",
+      "lng": -122.190395806176,
+      "name": "South Bellevue Station",
+      "stopCode": 56
+    },
+    {
+      "lat": 47.6081876814778,
+      "lines": "2",
+      "lng": -122.19114714966,
+      "name": "East Main Station",
+      "stopCode": 57
+    },
+    {
+      "lat": 47.6152231519934,
+      "lines": "2",
+      "lng": -122.192084303993,
+      "name": "Bellevue Downtown Station",
+      "stopCode": 58
+    },
+    {
+      "lat": 47.6179673467048,
+      "lines": "2",
+      "lng": -122.183761793767,
+      "name": "Wilburton Station",
+      "stopCode": 59
+    },
+    {
+      "lat": 47.6237731891775,
+      "lines": "2",
+      "lng": -122.178573081485,
+      "name": "Spring District/120th Station",
+      "stopCode": 60
+    },
+    {
+      "lat": 47.6244483620133,
+      "lines": "2",
+      "lng": -122.165640324067,
+      "name": "Bel-Red/130th Station",
+      "stopCode": 61
+    },
+    {
+      "lat": 47.6363096313489,
+      "lines": "2",
+      "lng": -122.138919608185,
+      "name": "Overlake Village Station",
+      "stopCode": 62
+    },
+    {
+      "lat": 47.6448415828875,
+      "lines": "2",
+      "lng": -122.133628215678,
+      "name": "Redmond Technology Center Station",
+      "stopCode": 63
+    },
+    {
+      "lat": 47.662,
+      "lines": "2",
+      "lng": -122.118,
+      "name": "Marymoor Village Station",
+      "stopCode": 64
+    },
+    {
+      "lat": 47.6732,
+      "lines": "2",
+      "lng": -122.1248,
+      "name": "Downtown Redmond Station",
+      "stopCode": 65
+    }
+  ],
+  "version": 1
+}

--- a/data/test_bake_walksheds.py
+++ b/data/test_bake_walksheds.py
@@ -1,0 +1,223 @@
+"""Tests for the walkshed bake script."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bake_walksheds import (
+    DEFAULT_OPTIONS,
+    KEY_RE,
+    _round_coords,
+    bake,
+    bake_one,
+    make_key,
+    write_atomic,
+)
+
+
+# ── Helpers ──
+
+
+def _isochrone_fc(minutes=5):
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"contour": minutes},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[
+                        [-122.337123456789, 47.611123456789],
+                        [-122.336, 47.612],
+                        [-122.335, 47.611],
+                        [-122.337123456789, 47.611123456789],
+                    ]],
+                },
+            }
+        ],
+    }
+
+
+def _mock_client(response_fc=None):
+    """Build an httpx.Client mock that returns response_fc."""
+    if response_fc is None:
+        response_fc = _isochrone_fc()
+    client = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = response_fc
+    resp.raise_for_status = MagicMock()
+    client.get.return_value = resp
+    return client
+
+
+def _index(*entries):
+    return {
+        "version": 1,
+        "stations": [
+            {"name": n, "lines": l, "stopCode": c, "lng": lng, "lat": lat}
+            for (n, l, c, lng, lat) in entries
+        ],
+    }
+
+
+# ── make_key + KEY_RE ──
+
+
+@pytest.mark.unit
+class TestKey:
+    def test_make_key_format(self):
+        assert make_key("1,2", 50, 5) == "1,2-50-5"
+        assert make_key("1", 54, 10) == "1-54-10"
+        assert make_key("2", 60, 15) == "2-60-15"
+
+    def test_key_regex_accepts_valid(self):
+        assert KEY_RE.match("1,2-50-5")
+        assert KEY_RE.match("1-54-10")
+        assert KEY_RE.match("2-65-15")
+
+    def test_key_regex_rejects_invalid(self):
+        assert not KEY_RE.match("3-50-5")
+        assert not KEY_RE.match("1,2,3-50-5")
+        assert not KEY_RE.match("1-50")
+        assert not KEY_RE.match("foo")
+
+
+# ── _round_coords ──
+
+
+@pytest.mark.unit
+class TestRoundCoords:
+    def test_rounds_floats(self):
+        result = _round_coords([-122.337123456789, 47.611123456789])
+        assert result == [-122.337123, 47.611123]
+
+    def test_recursive_rounds_polygon(self):
+        fc = _isochrone_fc()
+        result = _round_coords(fc)
+        coord = result["features"][0]["geometry"]["coordinates"][0][0]
+        assert coord == [-122.337123, 47.611123]
+
+    def test_preserves_non_coord_values(self):
+        result = _round_coords({"contour": 5, "name": "x"})
+        assert result == {"contour": 5, "name": "x"}
+
+
+# ── bake_one ──
+
+
+@pytest.mark.unit
+class TestBakeOne:
+    def test_returns_rounded_fc(self):
+        client = _mock_client()
+        fc = bake_one(client, -122.337, 47.611, 5, "test-token")
+        assert fc["type"] == "FeatureCollection"
+        coord = fc["features"][0]["geometry"]["coordinates"][0][0]
+        assert coord == [-122.337123, 47.611123]
+
+    def test_passes_correct_url_and_params(self):
+        client = _mock_client()
+        bake_one(client, -122.337, 47.611, 10, "test-token")
+        call = client.get.call_args
+        assert "isochrone" in call.args[0]
+        assert "-122.337,47.611" in call.args[0]
+        assert call.kwargs["params"]["contours_minutes"] == 10
+        assert call.kwargs["params"]["polygons"] == "true"
+        assert call.kwargs["params"]["access_token"] == "test-token"
+
+    def test_raises_on_non_feature_collection(self):
+        client = _mock_client(response_fc={"type": "Polygon", "coordinates": []})
+        with pytest.raises(ValueError, match="Expected FeatureCollection"):
+            bake_one(client, -122.337, 47.611, 5, "test-token")
+
+
+# ── bake ──
+
+
+@pytest.mark.unit
+class TestBake:
+    def test_iterates_all_stations_and_options(self):
+        index = _index(
+            ("Westlake Station", "1,2", 50, -122.337, 47.611),
+            ("Stadium Station", "1", 54, -122.327, 47.591),
+        )
+        client = _mock_client()
+        with patch("bake_walksheds.time.sleep"):
+            output = bake(index, token="test-token", delay=0, client=client)
+
+        assert output["version"] == 1
+        assert "generated" in output
+        # 2 stations × 3 options = 6 entries
+        assert len(output["walksheds"]) == 6
+        assert "1,2-50-5" in output["walksheds"]
+        assert "1,2-50-10" in output["walksheds"]
+        assert "1,2-50-15" in output["walksheds"]
+        assert "1-54-5" in output["walksheds"]
+
+    def test_no_duplicate_keys(self):
+        index = _index(
+            ("Stadium Station", "1", 54, -122.327, 47.591),
+            ("Judkins Park Station", "2", 54, -122.30, 47.59),
+        )
+        client = _mock_client()
+        with patch("bake_walksheds.time.sleep"):
+            output = bake(index, token="test-token", delay=0, client=client)
+        # Same stop code 54 on two lines must produce two distinct keys.
+        assert "1-54-5" in output["walksheds"]
+        assert "2-54-5" in output["walksheds"]
+
+    def test_rate_limit_delay_called_n_minus_one_times(self):
+        index = _index(("Westlake Station", "1,2", 50, -122.337, 47.611))
+        client = _mock_client()
+        with patch("bake_walksheds.time.sleep") as mock_sleep:
+            bake(index, token="test-token", delay=0.05, client=client)
+        # 1 station × 3 options = 3 calls; sleep should fire between them = 2 times.
+        assert mock_sleep.call_count == 3 - 1
+        for call in mock_sleep.call_args_list:
+            assert call.args[0] == 0.05
+
+    def test_uses_default_options(self):
+        index = _index(("Westlake Station", "1,2", 50, -122.337, 47.611))
+        client = _mock_client()
+        with patch("bake_walksheds.time.sleep"):
+            output = bake(index, token="test-token", delay=0, client=client)
+        keys_for_station = [k for k in output["walksheds"] if k.startswith("1,2-50-")]
+        suffixes = sorted(int(k.rsplit("-", 1)[1]) for k in keys_for_station)
+        assert suffixes == list(DEFAULT_OPTIONS)
+
+
+# ── write_atomic ──
+
+
+@pytest.mark.unit
+class TestWriteAtomic:
+    def test_writes_json_file(self, tmp_path):
+        out = tmp_path / "walksheds.geojson"
+        write_atomic(out, {"hello": "world"})
+        assert out.exists()
+        assert json.loads(out.read_text()) == {"hello": "world"}
+
+    def test_creates_parent_dir(self, tmp_path):
+        out = tmp_path / "nested" / "dir" / "walksheds.geojson"
+        write_atomic(out, {"x": 1})
+        assert out.exists()
+
+    def test_no_lingering_tmp(self, tmp_path):
+        out = tmp_path / "walksheds.geojson"
+        write_atomic(out, {"x": 1})
+        assert not (tmp_path / "walksheds.geojson.tmp").exists()
+
+
+# ── token exfil safety ──
+
+
+@pytest.mark.unit
+class TestTokenExfilSafety:
+    def test_token_not_in_serialized_output(self):
+        index = _index(("Westlake Station", "1,2", 50, -122.337, 47.611))
+        client = _mock_client()
+        token = "pk.test_secret_token_value"
+        with patch("bake_walksheds.time.sleep"):
+            output = bake(index, token=token, delay=0, client=client)
+        assert token not in json.dumps(output)

--- a/data/test_build_station_index.py
+++ b/data/test_build_station_index.py
@@ -1,0 +1,63 @@
+"""Tests for the station index builder."""
+
+import pytest
+
+from build_station_index import build, INDEX_VERSION
+
+
+def _feature(name, lines, stop_code, lng, lat, shared=False):
+    return {
+        "type": "Feature",
+        "properties": {
+            "name": name,
+            "line": "1-line" if "1" in lines else "2-line",
+            "lines": lines,
+            "stopCode": stop_code,
+            "shared": shared,
+        },
+        "geometry": {"type": "Point", "coordinates": [lng, lat]},
+    }
+
+
+def _fc(features):
+    return {"type": "FeatureCollection", "features": features}
+
+
+@pytest.mark.unit
+class TestBuild:
+    def test_basic_structure(self):
+        fc = _fc([_feature("Westlake Station", "1,2", 50, -122.337, 47.611, shared=True)])
+        result = build(fc)
+        assert result["version"] == INDEX_VERSION
+        assert isinstance(result["stations"], list)
+        assert len(result["stations"]) == 1
+        s = result["stations"][0]
+        assert s == {
+            "name": "Westlake Station",
+            "lines": "1,2",
+            "stopCode": 50,
+            "lng": -122.337,
+            "lat": 47.611,
+        }
+
+    def test_sorted_by_lines_then_stop_code(self):
+        fc = _fc([
+            _feature("Z-Station", "2", 60, -122.0, 47.5),
+            _feature("Y-Station", "1", 55, -122.1, 47.4),
+            _feature("X-Station", "1,2", 50, -122.2, 47.3, shared=True),
+            _feature("W-Station", "1", 54, -122.3, 47.2),
+        ])
+        result = build(fc)
+        ordering = [(s["lines"], s["stopCode"]) for s in result["stations"]]
+        assert ordering == [("1", 54), ("1", 55), ("1,2", 50), ("2", 60)]
+
+    def test_preserves_all_fields(self):
+        fc = _fc([_feature("Stadium Station", "1", 54, -122.327, 47.591)])
+        result = build(fc)
+        s = result["stations"][0]
+        assert set(s.keys()) == {"name", "lines", "stopCode", "lng", "lat"}
+
+    def test_preserves_shared_lines_string(self):
+        fc = _fc([_feature("Shared", "1,2", 50, -122.0, 47.0, shared=True)])
+        result = build(fc)
+        assert result["stations"][0]["lines"] == "1,2"

--- a/data/test_compare_station_index.py
+++ b/data/test_compare_station_index.py
@@ -1,0 +1,160 @@
+"""Tests for the station index drift detector."""
+
+import pytest
+
+from compare_station_index import (
+    Drift,
+    Report,
+    compare,
+    haversine,
+    _live_station_map,
+)
+
+
+# ── Helpers ──
+
+
+def _index(*entries):
+    return {
+        "version": 1,
+        "stations": [
+            {"name": n, "lines": l, "stopCode": c, "lng": lng, "lat": lat}
+            for (n, l, c, lng, lat) in entries
+        ],
+    }
+
+
+def _live_feature(name, lng, lat, status="Existing / Under Construction"):
+    # Mirror SDOT feature shape — process.py reads list(values())[2] as the name.
+    return {
+        "type": "Feature",
+        "properties": {"OBJECTID": 1, "ID": "x", "NAME": name, "STATUS": status},
+        "geometry": {"type": "Point", "coordinates": [lng, lat]},
+    }
+
+
+def _live_fc(*features):
+    return {"type": "FeatureCollection", "features": list(features)}
+
+
+# ── haversine ──
+
+
+@pytest.mark.unit
+class TestHaversine:
+    def test_zero_distance(self):
+        assert haversine(-122.337, 47.611, -122.337, 47.611) == pytest.approx(0.0, abs=0.01)
+
+    def test_known_distance(self):
+        # Roughly 100 m east at lat 47.6
+        d = haversine(-122.337, 47.611, -122.337 + 0.00133, 47.611)
+        assert 90 < d < 110
+
+    def test_symmetric(self):
+        a = haversine(-122.337, 47.611, -122.30, 47.65)
+        b = haversine(-122.30, 47.65, -122.337, 47.611)
+        assert a == pytest.approx(b)
+
+
+# ── compare ──
+
+
+@pytest.mark.unit
+class TestCompare:
+    def test_exact_match_passes(self):
+        index = _index(("Westlake Station", "1,2", 50, -122.337, 47.611))
+        live = _live_fc(_live_feature("Westlake Station", -122.337, 47.611))
+        report = compare(index, live)
+        assert report.ok
+        assert report.added == []
+        assert report.removed == []
+        assert report.drifted == []
+
+    def test_drift_below_threshold_passes(self):
+        index = _index(("Westlake Station", "1,2", 50, -122.337, 47.611))
+        # ~15 m east
+        live = _live_fc(_live_feature("Westlake Station", -122.337 + 0.0002, 47.611))
+        report = compare(index, live, threshold_m=75)
+        assert report.ok
+
+    def test_drift_above_threshold_fails(self):
+        index = _index(("Westlake Station", "1,2", 50, -122.337, 47.611))
+        # ~150 m east
+        live = _live_fc(_live_feature("Westlake Station", -122.337 + 0.002, 47.611))
+        report = compare(index, live, threshold_m=75)
+        assert not report.ok
+        assert len(report.drifted) == 1
+        assert report.drifted[0].name == "Westlake Station"
+        assert report.drifted[0].distance_m > 75
+
+    def test_added_station_in_live(self):
+        index = _index(("Westlake Station", "1,2", 50, -122.337, 47.611))
+        live = _live_fc(
+            _live_feature("Westlake Station", -122.337, 47.611),
+            _live_feature("Brand New Station", -122.30, 47.65),
+        )
+        report = compare(index, live)
+        assert not report.ok
+        assert report.added == ["Brand New Station"]
+
+    def test_removed_station_in_live(self):
+        index = _index(
+            ("Westlake Station", "1,2", 50, -122.337, 47.611),
+            ("Stadium Station", "1", 54, -122.327, 47.591),
+        )
+        live = _live_fc(_live_feature("Westlake Station", -122.337, 47.611))
+        report = compare(index, live)
+        assert not report.ok
+        assert report.removed == ["Stadium Station"]
+
+    def test_missing_stations_exempt_from_removed(self):
+        # Lynnwood City Center is in process.MISSING_STATIONS
+        index = _index(("Lynnwood City Center Station", "1,2", 40, -122.295, 47.816))
+        live = _live_fc()  # SDOT doesn't publish it yet
+        report = compare(index, live)
+        assert report.removed == []
+        assert report.ok
+
+    def test_missing_stations_exempt_from_drift(self):
+        # Lynnwood is in MISSING_STATIONS — its index coords are approximate.
+        index = _index(("Lynnwood City Center Station", "1,2", 40, -122.295, 47.816))
+        live = _live_fc(_live_feature("Lynnwood City Center Station", -122.20, 47.90))
+        report = compare(index, live)
+        assert report.drifted == []
+
+    def test_name_map_normalization(self):
+        # NAME_MAP: "NE 145th Station" -> "Shoreline South/148th Station"
+        index = _index(("Shoreline South/148th Station", "1,2", 43, -122.33, 47.73))
+        live = _live_fc(_live_feature("NE 145th Station", -122.33, 47.73))
+        report = compare(index, live)
+        assert report.ok
+
+    def test_filters_tacoma_link(self):
+        index = _index(("Westlake Station", "1,2", 50, -122.337, 47.611))
+        live = _live_fc(
+            _live_feature("Westlake Station", -122.337, 47.611),
+            _live_feature("Tacoma Dome Station", -122.43, 47.24),
+        )
+        report = compare(index, live)
+        assert report.ok
+        assert "Tacoma Dome Station" not in report.added
+
+    def test_filters_non_existing_status(self):
+        index = _index(("Westlake Station", "1,2", 50, -122.337, 47.611))
+        live = _live_fc(
+            _live_feature("Westlake Station", -122.337, 47.611),
+            _live_feature("Future Station", -122.30, 47.65, status="Planned"),
+        )
+        report = compare(index, live)
+        assert report.ok
+
+
+@pytest.mark.unit
+class TestReport:
+    def test_empty_report_is_ok(self):
+        assert Report().ok
+
+    def test_any_finding_makes_not_ok(self):
+        assert not Report(added=["x"]).ok
+        assert not Report(removed=["x"]).ok
+        assert not Report(drifted=[Drift("x", 100)]).ok

--- a/data/test_process.py
+++ b/data/test_process.py
@@ -122,3 +122,25 @@ class TestStationData:
         assert by_name["Lynnwood City Center Station"] == 40
         assert by_name["Federal Way Downtown Station"] == 68
         assert by_name["Downtown Redmond Station"] == 65
+
+
+class TestBakeIndexConsistency:
+    """If a baked walkshed file exists, every station-index entry must be present."""
+
+    @pytest.mark.unit
+    def test_walkshed_keys_cover_station_index(self):
+        bake_path = os.path.join(PUBLIC, "walksheds.geojson")
+        index_path = os.path.join(ROOT, "data", "station-index.json")
+        if not os.path.exists(bake_path) or not os.path.exists(index_path):
+            pytest.skip("walksheds.geojson not present — skipping cross-check")
+
+        with open(bake_path) as f:
+            bake = json.load(f)
+        with open(index_path) as f:
+            index = json.load(f)
+
+        keys = set(bake["walksheds"].keys())
+        for station in index["stations"]:
+            for minutes in (5, 10, 15):
+                key = f"{station['lines']}-{station['stopCode']}-{minutes}"
+                assert key in keys, f"Missing baked walkshed for {key} ({station['name']})"

--- a/data/test_refresh.py
+++ b/data/test_refresh.py
@@ -151,7 +151,11 @@ class TestDownload:
         written = json.loads((raw / "light-rail-stations.geojson").read_text())
         assert len(written["features"]) == 40
 
-        mock_proc.assert_called_once()
+        # download() runs process.py then build_station_index.py.
+        assert mock_proc.call_count == 2
+        scripts = [call.args[0][1] for call in mock_proc.call_args_list]
+        assert any("process.py" in s for s in scripts)
+        assert any("build_station_index.py" in s for s in scripts)
 
     def test_urls_are_well_formed(self):
         assert "FeatureServer/14" in STATIONS_URL


### PR DESCRIPTION
## Summary

Lays the infrastructure to precompute Mapbox walking-distance isochrones and serve them as a static asset, addressing tommyroar/walksheds#5. This is **PR 1 of 3**:

1. **PR 1 (this one)** — workflow + scripts + station index + tests. Does NOT touch `src/`; the app still uses the live API after this merges.
2. **PR 2** — auto-opened by the workflow on first dispatch with `public/walksheds.geojson` + any refreshed SDOT data.
3. **PR 3** — flips `src/mapbox.js` to consume the static file.

## What's in this PR

### New scripts (Python, PEP 723 inline deps)

- **`data/build_station_index.py`** — pure derivation from `public/all-stations.geojson` → `data/station-index.json`. Deterministic ordering by `(lines, stopCode)` so diffs are minimal.
- **`data/station-index.json`** — canonical, human-reviewable list of all 38 stations (seed). The single source of truth that the bake script iterates over and the drift detector compares against.
- **`data/compare_station_index.py`** — fetches the live SDOT ArcGIS feed (reusing `refresh.fetch_geojson`), reports `added` / `removed` / `drifted` stations against the index. Haversine distance with a 75 m threshold (SDOT publishes ~30 m jitter; 50 m over-triggers). Respects `NAME_MAP` and `MISSING_STATIONS` from `data/process.py`. Writes a Markdown summary to `$GITHUB_STEP_SUMMARY` and exits non-zero on drift.
- **`data/bake_walksheds.py`** — reads the index, calls Mapbox Isochrone API for each `(station × {5, 10, 15} min)`, writes `public/walksheds.geojson` keyed by `"{lines}-{stopCode}-{minutes}"`. Coords rounded to 6 decimals (~11 cm) to keep diffs minimal. ~6 s + latency for 114 calls. Includes a token-exfil safety check (asserts the token doesn't appear in the serialized output) and atomic writes.

### Tests (pytest, mocked I/O)

- `data/test_build_station_index.py` — pure-function tests
- `data/test_compare_station_index.py` — exact match, drift above/below threshold, added/removed, `NAME_MAP` normalization, `MISSING_STATIONS` exemption, Tacoma Link filter
- `data/test_bake_walksheds.py` — `bake_one` URL/params, `bake` iteration + key uniqueness across shared/exclusive line collisions, rate-limit `time.sleep` count, atomic write, token exfil safety
- `data/test_process.py` — added `TestBakeIndexConsistency` cross-check (skips if `walksheds.geojson` not present)
- `data/test_refresh.py` — updated `test_writes_files_and_runs_process` to expect two `subprocess.check_call` invocations now that `refresh.py` also runs `build_station_index.py`

### Workflow

**`.github/workflows/refresh-walksheds.yml`**:
- Triggers: `schedule: cron: "0 8 1 * *"` (1st of month, 08:00 UTC) + `workflow_dispatch`
- `permissions: contents: write, pull-requests: write`
- `concurrency: walkshed-refresh`
- Steps: refresh SDOT raw → reprocess → build index → compare index (`continue-on-error`) → bake → `pytest` → `npm run build` smoke → `peter-evans/create-pull-request@v6` with `add-paths` whitelist
- On compare failure, a follow-up step adds the `drift-detected` label to the auto-opened PR
- Mapbox token comes from the existing `MAPBOX_ACCESS_TOKEN` secret

### Other changes

- `data/refresh.py` now invokes `build_station_index.py` after `process.py` so a single `uv run data/refresh.py` rebuilds everything

## Local validation

- `cd data && python3 -m pytest -v` → **57 passed, 1 skipped** (the cross-check skips because `walksheds.geojson` doesn't exist yet)
- No JS changes in this PR; existing `npm run lint` / `test` / `build` are unaffected and CI will validate

## Next steps after merge

1. Manually dispatch `refresh-walksheds.yml` from the Actions UI to populate `public/walksheds.geojson` (PR 2)
2. After PR 2 merges, open PR 3 to switch `src/mapbox.js` to the static lookup

## Test plan

- [ ] CI passes (lint + test + build)
- [ ] Workflow file is parseable (GitHub will surface syntax errors after merge)
- [ ] Trigger `refresh-walksheds.yml` via Actions UI; verify it opens PR 2 with only the whitelisted files
- [ ] Confirm `public/walksheds.geojson` contains 114 entries and zero token leaks
- [ ] Verify the `drift-detected` label is wired up (test by simulating drift in a fork or trust the conditional)

https://claude.ai/code/session_01T6igJDobt63Tc3gymhaMNW