### PR TITLE
Fix mobile UI bugs: legend positioning, pinch-to-zoom, search zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="color-scheme" content="light" />
     <meta name="supported-color-schemes" content="light" />
     <title>Walksheds — Seattle Light Rail Explorer</title>

--- a/src/useNavigation.js
+++ b/src/useNavigation.js
@@ -60,19 +60,27 @@ export function useNavigation({ graphRef, selectedStationRef, currentLine, selec
   }, [navigateDirection, selectedStationRef])
 
   // Touch swipe navigation (mobile)
+  // Only respond to single-finger swipes; ignore multi-touch (pinch-to-zoom)
   useEffect(() => {
     let startX = 0
     let startY = 0
+    let tracking = false
     const SWIPE_THRESHOLD = 50
 
     const handleTouchStart = (e) => {
       if (!selectedStationRef.current) return
+      if (e.touches.length !== 1) {
+        tracking = false
+        return
+      }
+      tracking = true
       startX = e.touches[0].clientX
       startY = e.touches[0].clientY
     }
 
     const handleTouchEnd = (e) => {
-      if (!selectedStationRef.current) return
+      if (!selectedStationRef.current || !tracking) return
+      tracking = false
       const dx = e.changedTouches[0].clientX - startX
       const dy = e.changedTouches[0].clientY - startY
 

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -31,7 +31,7 @@ body,
 
 .line-legend {
   position: absolute;
-  bottom: 32px;
+  bottom: calc(32px + env(safe-area-inset-bottom, 0px));
   left: 16px;
   z-index: 10;
   background: #ffffff;
@@ -105,14 +105,14 @@ body,
 .line-legend.collapsed {
   left: 50%;
   transform: translateX(-50%);
-  bottom: 12px;
+  bottom: calc(12px + env(safe-area-inset-bottom, 0px));
   padding: 6px 10px;
   border-radius: 16px;
   max-height: none;
   overflow: visible;
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   justify-content: center;
   gap: 6px;
   max-width: calc(100vw - 24px);
@@ -249,7 +249,7 @@ body,
 
 @media (max-width: 480px) {
   .line-legend:not(.collapsed) {
-    bottom: 16px;
+    bottom: calc(16px + env(safe-area-inset-bottom, 0px));
     left: 8px;
     padding: 0 14px 10px;
     max-height: 40vh;
@@ -1431,5 +1431,9 @@ body,
     width: 180px;
     top: 10px;
     right: 10px;
+  }
+
+  .poi-search-input {
+    font-size: 16px;
   }
 }


### PR DESCRIPTION
- Use viewport-fit=cover and env(safe-area-inset-bottom) so collapsed
  legend clears the iOS Safari toolbar
- Change collapsed legend to flex-wrap: nowrap so the expand chevron
  stays on the same line
- Only track single-finger swipes in useNavigation touch handler,
  preventing pinch-to-zoom from triggering station navigation and
  snapping the view back to the walkshed bounds
- Set search input font-size to 16px on mobile to prevent iOS
  auto-zoom on focus

Fixes #20

https://claude.ai/code/session_011TpDj8w4nV1Hc1YoVN6acN