### PR TITLE
Category pills + per-branch dev preview workflow

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -1,0 +1,59 @@
+name: Deploy branch preview to GitHub Pages
+
+# Manually-triggered branch preview. Builds whichever ref you pick from the
+# "Run workflow" dropdown (or pass ref=… via API) and replaces whatever is
+# currently on Pages. The next push to main will overwrite it via deploy.yml,
+# which is the intended lifecycle — this is a quick dev preview, not a
+# long-lived staging environment.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or commit SHA to deploy (defaults to the dispatched ref)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Same group as deploy.yml so a main push and a branch dispatch serialize
+# rather than racing — latest finished deploy wins.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm install
+
+      - run: npm run build
+        env:
+          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-preview-claude-move-data-to-repo-DMJZ6.yml
+++ b/.github/workflows/deploy-preview-claude-move-data-to-repo-DMJZ6.yml
@@ -1,26 +1,22 @@
-name: Deploy branch preview to GitHub Pages
+name: Deploy preview — claude/move-data-to-repo-DMJZ6
 
-# Manually-triggered branch preview. Builds whichever ref you pick from the
-# "Run workflow" dropdown (or pass ref=… via API) and replaces whatever is
-# currently on Pages. The next push to main will overwrite it via deploy.yml,
-# which is the intended lifecycle — this is a quick dev preview, not a
-# long-lived staging environment.
+# Dedicated dev preview for this branch. Auto-deploys on every push to
+# the branch, plus a no-input workflow_dispatch for ad-hoc retriggers.
+# When this branch's PR is merged, .github/workflows/cleanup-merged-preview.yml
+# on main deletes this file from main.
 
 on:
+  push:
+    branches: ['claude/move-data-to-repo-DMJZ6']
   workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Branch or commit SHA to deploy (defaults to the dispatched ref)'
-        required: false
-        type: string
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Same group as deploy.yml so a main push and a branch dispatch serialize
-# rather than racing — latest finished deploy wins.
+# Same group as deploy.yml so a main push and this preview serialize
+# rather than racing through the single Pages slot.
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -30,8 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
 
       - uses: actions/setup-node@v4
         with:

--- a/src/LineLegend.jsx
+++ b/src/LineLegend.jsx
@@ -20,7 +20,6 @@ export default function LineLegend({
   position,
   poiFilters,
   poiTagColors,
-  tagCategories,
   onRemovePoiFilter,
   onClearPoiFilters,
   onTagSelect,
@@ -33,24 +32,6 @@ export default function LineLegend({
       if (color) tagColorMap[tag] = color
       tagCountMap[tag] = count
     }
-  }
-
-  // Color key: which tag-categories are present in the current view, with their tag counts.
-  let visibleCategories = []
-  if (tagCategories?.tag_to_category && poiTagColors?.length) {
-    const counts = {}
-    for (const { tag, count } of poiTagColors) {
-      const catId = tagCategories.tag_to_category[tag]
-      if (catId) counts[catId] = (counts[catId] || 0) + count
-    }
-    visibleCategories = Object.entries(counts)
-      .map(([catId, total]) => ({
-        id: catId,
-        label: tagCategories.categories[catId]?.label || catId,
-        color: tagCategories.categories[catId]?.color || '#999',
-        count: total,
-      }))
-      .sort((a, b) => b.count - a.count)
   }
 
   const posClass = position === 'bottom-right' ? 'bottom-right' : ''
@@ -215,22 +196,6 @@ export default function LineLegend({
           )
         })}
       </div>
-
-      {visibleCategories.length > 0 && (
-        <>
-          <div className="legend-divider" />
-          <h3 className="legend-title">Tag colors</h3>
-          <div className="legend-tag-key">
-            {visibleCategories.map(c => (
-              <div key={c.id} className="legend-tag-key-item">
-                <span className="legend-tag-key-swatch" style={{ background: c.color }} />
-                <span className="legend-tag-key-label">{c.label}</span>
-                <span className="legend-tag-key-count">{c.count}</span>
-              </div>
-            ))}
-          </div>
-        </>
-      )}
 
       {poiFilters && poiFilters.size > 0 && (
         <>

--- a/src/POISearch.jsx
+++ b/src/POISearch.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 
-export default function POISearch({ availableTags, activeFilters, poiFeatures, expandedTag, onExpandTag, onAddFilter, onRemoveFilter, onClearFilters, onPoiSelect }) {
+export default function POISearch({ availableTags, activeFilters, poiFeatures, expandedTag, onExpandTag, onAddFilter, onRemoveFilter, onClearFilters, onPoiSelect, tagCategories, enabledCategories, onToggleCategory }) {
   const [query, setQuery] = useState('')
   const [showDropdown, setShowDropdown] = useState(false)
   const [highlightIdx, setHighlightIdx] = useState(0)
@@ -20,6 +20,21 @@ export default function POISearch({ availableTags, activeFilters, poiFeatures, e
     return { tagColors: colors, tagCounts: counts }
   }, [availableTags])
 
+  // Sub-categories (tags) only surface when their parent category is enabled.
+  const visibleTags = useMemo(() => {
+    if (!tagCategories || !enabledCategories || enabledCategories.size === 0) return []
+    const tagToCat = tagCategories.tag_to_category || {}
+    return availableTags.filter(({ tag }) => enabledCategories.has(tagToCat[tag]))
+  }, [availableTags, enabledCategories, tagCategories])
+
+  // Ordered category list for the pills row, sorted alphabetically by label.
+  const categoryEntries = useMemo(() => {
+    if (!tagCategories?.categories) return []
+    return Object.entries(tagCategories.categories)
+      .map(([id, c]) => ({ id, label: c.label, color: c.color }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [tagCategories])
+
   // Features matching the expanded tag
   const poisForTag = useMemo(() => {
     if (!expandedTag || !poiFeatures) return []
@@ -36,15 +51,16 @@ export default function POISearch({ availableTags, activeFilters, poiFeatures, e
     items[poiHighlightIdx]?.scrollIntoView({ block: 'nearest' })
   }, [poiHighlightIdx])
 
-  // Filter available tags by search query, excluding already-active filters
-  // When query is empty, show top tags so arrow-key browsing works on focus
+  // Filter available tags by search query, excluding already-active filters.
+  // Source list is restricted to tags whose category is currently enabled.
+  // When query is empty, show top tags so arrow-key browsing works on focus.
   const matches = useMemo(() => {
-    const filtered = availableTags.filter(({ tag }) => !activeFilters.has(tag))
+    const filtered = visibleTags.filter(({ tag }) => !activeFilters.has(tag))
     if (!query.trim()) return filtered.slice(0, 8)
     return filtered
       .filter(({ tag }) => tag.includes(query.trim().toLowerCase()))
       .slice(0, 8)
-  }, [query, availableTags, activeFilters])
+  }, [query, visibleTags, activeFilters])
 
   const handleSelect = useCallback((tag) => {
     onAddFilter(tag)
@@ -135,6 +151,28 @@ export default function POISearch({ availableTags, activeFilters, poiFeatures, e
 
   return (
     <div className="poi-search" ref={containerRef}>
+      {categoryEntries.length > 0 && (
+        <div className="poi-cat-pills">
+          {categoryEntries.map(({ id, label, color }) => {
+            const enabled = enabledCategories?.has(id)
+            return (
+              <button
+                key={id}
+                type="button"
+                className={`poi-cat-pill ${enabled ? 'enabled' : 'disabled'}`}
+                style={{
+                  borderColor: color,
+                  background: enabled ? color + '22' : 'transparent',
+                  color: enabled ? color : color + '99',
+                }}
+                onClick={() => onToggleCategory?.(id)}
+              >
+                {label}
+              </button>
+            )
+          })}
+        </div>
+      )}
       <div className="poi-search-input-row">
         <svg className="poi-search-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
           <circle cx="6.5" cy="6.5" r="5" stroke="currentColor" strokeWidth="1.5"/>

--- a/src/Walksheds.jsx
+++ b/src/Walksheds.jsx
@@ -3,7 +3,7 @@ import { buildGraph, isJunction, getJunctionHints } from './routeGraph'
 import { fetchWalkshed, getLargestEnabledBounds } from './mapbox'
 import { WALKSHED_OPTIONS, LINE_COLORS, WALKSHED_ACCENT_LIGHT, WALKSHED_ACCENT_DARK, SEATTLE_CENTER, SEATTLE_ZOOM, POI_FILES } from './constants'
 import { parseStationPath, buildStationPath, findStationByCode, parseWalkshedParams, buildWalkshedParams } from './deepLink'
-import { filterPOIsInWalkshed, filterByTags, getAvailableTags, mergeFeatureCollections } from './poiUtils'
+import { filterPOIsInWalkshed, filterByCategoriesOrTags, getAvailableTags, mergeFeatureCollections } from './poiUtils'
 import { useNavigation } from './useNavigation'
 import MapView from './MapView'
 import LineLegend from './LineLegend'
@@ -103,6 +103,7 @@ export default function Walksheds() {
   const [poiData, setPoiData] = useState({})
   const [tagCategories, setTagCategories] = useState(null)
   const [poiFilters, setPoiFilters] = useState(new Set())
+  const [enabledCategories, setEnabledCategories] = useState(new Set())
   const [poiPopup, setPoiPopup] = useState(null)
   const [expandedPoiTag, setExpandedPoiTag] = useState(null)
   const mapViewRef = useRef(null)
@@ -233,10 +234,23 @@ export default function Walksheds() {
   )
 
   const visiblePois = useMemo(() => {
-    if (poiFilters.size === 0) return walkshedPois
-    const filtered = filterByTags(walkshedPois.features, poiFilters)
+    const filtered = filterByCategoriesOrTags(
+      walkshedPois.features,
+      enabledCategories,
+      poiFilters,
+      tagCategories?.tag_to_category,
+    )
     return { type: 'FeatureCollection', features: filtered }
-  }, [walkshedPois, poiFilters])
+  }, [walkshedPois, enabledCategories, poiFilters, tagCategories])
+
+  const handleToggleCategory = useCallback((catId) => {
+    setEnabledCategories(prev => {
+      const next = new Set(prev)
+      if (next.has(catId)) next.delete(catId)
+      else next.add(catId)
+      return next
+    })
+  }, [])
 
   const handleAddPoiFilter = useCallback((tag) => {
     setPoiFilters(prev => new Set([...prev, tag]))
@@ -391,6 +405,9 @@ export default function Walksheds() {
           onRemoveFilter={handleRemovePoiFilter}
           onClearFilters={handleClearPoiFilters}
           onPoiSelect={handlePoiSelect}
+          tagCategories={tagCategories}
+          enabledCategories={enabledCategories}
+          onToggleCategory={handleToggleCategory}
         />
       )}
 
@@ -406,7 +423,6 @@ export default function Walksheds() {
         position={legendPosition}
         poiFilters={poiFilters}
         poiTagColors={availableTags}
-        tagCategories={tagCategories}
         onRemovePoiFilter={handleRemovePoiFilter}
         onClearPoiFilters={handleClearPoiFilters}
         onTagSelect={setExpandedPoiTag}

--- a/src/__tests__/poiUtils.test.js
+++ b/src/__tests__/poiUtils.test.js
@@ -4,6 +4,7 @@ import {
   filterPOIsInWalkshed,
   getAvailableTags,
   filterByTags,
+  filterByCategoriesOrTags,
   mergeFeatureCollections,
 } from '../poiUtils'
 
@@ -199,6 +200,70 @@ describe('filterByTags', () => {
     ]
     const result = filterByTags(mixed, new Set(['pizza']))
     expect(result).toHaveLength(2)
+  })
+})
+
+describe('filterByCategoriesOrTags', () => {
+  const features = [
+    makeFeature(0, 0, { tags: ['pizza', 'italian'] }),       // cuisine
+    makeFeature(0, 0, { tags: ['sushi', 'japanese'] }),      // cuisine
+    makeFeature(0, 0, { tags: ['takeaway', 'wifi'] }),       // service + vibe
+    makeFeature(0, 0, { tags: ['vegetarian'] }),             // diet
+    makeFeature(0, 0, { tags: [] }),                         // none
+  ]
+  const tagToCategory = {
+    pizza: 'cuisine', italian: 'cuisine', sushi: 'cuisine', japanese: 'cuisine',
+    takeaway: 'service', wifi: 'vibe', vegetarian: 'diet',
+  }
+
+  it('returns empty array when nothing is enabled or active', () => {
+    expect(filterByCategoriesOrTags(features, new Set(), new Set(), tagToCategory)).toEqual([])
+    expect(filterByCategoriesOrTags(features, null, null, tagToCategory)).toEqual([])
+  })
+
+  it('matches features whose tag belongs to an enabled category', () => {
+    const result = filterByCategoriesOrTags(
+      features, new Set(['cuisine']), new Set(), tagToCategory,
+    )
+    expect(result).toHaveLength(2) // pizza + sushi POIs
+  })
+
+  it('matches features by active tag filter alone', () => {
+    const result = filterByCategoriesOrTags(
+      features, new Set(), new Set(['wifi']), tagToCategory,
+    )
+    expect(result).toHaveLength(1) // takeaway+wifi POI
+  })
+
+  it('unions categories and active tags (additive)', () => {
+    // diet category enabled + sushi tag filter → vegetarian POI + sushi POI
+    const result = filterByCategoriesOrTags(
+      features, new Set(['diet']), new Set(['sushi']), tagToCategory,
+    )
+    expect(result).toHaveLength(2)
+  })
+
+  it('multiple enabled categories OR together', () => {
+    const result = filterByCategoriesOrTags(
+      features, new Set(['service', 'diet']), new Set(), tagToCategory,
+    )
+    expect(result).toHaveLength(2) // takeaway POI + vegetarian POI
+  })
+
+  it('skips features with no tags array', () => {
+    const mixed = [...features, { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [0, 0] } }]
+    const result = filterByCategoriesOrTags(
+      mixed, new Set(['cuisine']), new Set(), tagToCategory,
+    )
+    expect(result).toHaveLength(2) // unchanged
+  })
+
+  it('ignores tags whose category is not enabled', () => {
+    // wifi belongs to vibe; only enable cuisine → wifi POI excluded
+    const result = filterByCategoriesOrTags(
+      features, new Set(['cuisine']), new Set(), tagToCategory,
+    )
+    expect(result.every(f => f.properties.tags.some(t => tagToCategory[t] === 'cuisine'))).toBe(true)
   })
 })
 

--- a/src/poiUtils.js
+++ b/src/poiUtils.js
@@ -82,6 +82,38 @@ export function filterByTags(features, activeTags) {
 }
 
 /**
+ * Additive filter: a POI is visible if any of its tags is in an enabled
+ * category OR any of its tags is in the active tag filters. With nothing
+ * enabled and no active filters, returns an empty array (additive default).
+ *
+ * @param {Array} features - GeoJSON features
+ * @param {Set<string>} enabledCategories - tag-category ids the user has activated
+ * @param {Set<string>} activeTags - explicit tag filters
+ * @param {Object} [tagToCategory] - map from tag name → category id
+ * @returns {Array} filtered features
+ */
+export function filterByCategoriesOrTags(features, enabledCategories, activeTags, tagToCategory) {
+  const hasCats = enabledCategories && enabledCategories.size > 0
+  const hasTags = activeTags && activeTags.size > 0
+  if (!hasCats && !hasTags) return []
+  return features.filter(f => {
+    const tags = f.properties?.tags
+    if (!Array.isArray(tags)) return false
+    if (hasCats && tagToCategory) {
+      for (const t of tags) {
+        if (enabledCategories.has(tagToCategory[t])) return true
+      }
+    }
+    if (hasTags) {
+      for (const t of tags) {
+        if (activeTags.has(t)) return true
+      }
+    }
+    return false
+  })
+}
+
+/**
  * Merge multiple FeatureCollections into one.
  * @param {...Object} fcs - GeoJSON FeatureCollections
  * @returns {Object} merged FeatureCollection

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -1127,43 +1127,40 @@ body,
   color: #5bb8f0;
 }
 
-/* ── Legend: tag-category color key ── */
+/* ── POI category pills (sit above the search input) ── */
 
-.legend-tag-key {
+.poi-cat-pills {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px 10px;
-  margin-top: 4px;
+  gap: 4px;
+  padding: 6px 8px 4px;
 }
 
-.legend-tag-key-item {
+.poi-cat-pill {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  border: 1px solid;
   font-size: 11px;
-  line-height: 1.4;
+  line-height: 1;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.1s, background 0.1s;
 }
 
-.legend-tag-key-swatch {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
-  flex-shrink: 0;
+.poi-cat-pill.disabled {
+  opacity: 0.55;
 }
 
-.legend-tag-key-label {
-  color: inherit;
+.poi-cat-pill.disabled:hover {
+  opacity: 0.85;
 }
 
-.legend-tag-key-count {
-  color: #888;
-  font-variant-numeric: tabular-nums;
-  font-size: 10px;
-}
-
-.app.dark .legend-tag-key-count {
-  color: #aaa;
+.poi-cat-pill.enabled {
+  font-weight: 500;
 }
 
 /* ── Legend: POI filter tags ── */


### PR DESCRIPTION
Brings the additional changes since PR #25 onto main:

- `10ff9ad` — Add branch-preview deploy workflow (cherry-picked, superseded by `a1ef629`)
- `3578220` — Replace legend tag-color key with category pills near search bar
- `a1ef629` — Per-branch deploy preview: replace dispatch-with-ref with auto-deploy

Note: PR #25's content was reverted then re-applied via direct push to main (commit `ad9be88`) so this PR has a clean diff against main.

When merged, `cleanup-merged-preview.yml` on main will fire and delete `.github/workflows/deploy-preview-claude-move-data-to-repo-DMJZ6.yml` from main automatically.

https://claude.ai/code/session_017mK6QqZnT9BtgZvFme3BGN

---
_Generated by [Claude Code](https://claude.ai/code/session_017mK6QqZnT9BtgZvFme3BGN)_