### PR TITLE
Reorganize POI filters: 4 main pills + unified tag chip styling

### DIFF
--- a/.github/workflows/deploy-preview-claude-reorganize-poi-filters-6w4TU.yml
+++ b/.github/workflows/deploy-preview-claude-reorganize-poi-filters-6w4TU.yml
@@ -1,0 +1,53 @@
+name: Deploy preview — claude/reorganize-poi-filters-6w4TU
+
+# Dedicated dev preview for this branch. Auto-deploys on every push to
+# the branch, plus a no-input workflow_dispatch for ad-hoc retriggers.
+# When this branch's PR is merged, .github/workflows/cleanup-merged-preview.yml
+# on main deletes this file from main.
+
+on:
+  push:
+    branches: ['claude/reorganize-poi-filters-6w4TU']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Same group as deploy.yml so a main push and this preview serialize
+# rather than racing through the single Pages slot.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm install
+
+      - run: npm run build
+        env:
+          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/POISearch.jsx
+++ b/src/POISearch.jsx
@@ -1,6 +1,19 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 
-export default function POISearch({ availableTags, activeFilters, poiFeatures, expandedTag, onExpandTag, onAddFilter, onRemoveFilter, onClearFilters, onPoiSelect, tagCategories, enabledCategories, onToggleCategory }) {
+export default function POISearch({
+  availableTags,
+  activeFilters,
+  poiFeatures,
+  expandedTag,
+  onExpandTag,
+  onAddFilter,
+  onRemoveFilter,
+  onClearFilters,
+  onPoiSelect,
+  mainCategories,
+  enabledCategories,
+  onToggleCategory,
+}) {
   const [query, setQuery] = useState('')
   const [showDropdown, setShowDropdown] = useState(false)
   const [highlightIdx, setHighlightIdx] = useState(0)
@@ -9,7 +22,6 @@ export default function POISearch({ availableTags, activeFilters, poiFeatures, e
   const containerRef = useRef(null)
   const poiListRef = useRef(null)
 
-  // Build tag → color and tag → count lookups from availableTags
   const { tagColors, tagCounts } = useMemo(() => {
     const colors = {}
     const counts = {}
@@ -20,22 +32,6 @@ export default function POISearch({ availableTags, activeFilters, poiFeatures, e
     return { tagColors: colors, tagCounts: counts }
   }, [availableTags])
 
-  // Sub-categories (tags) only surface when their parent category is enabled.
-  const visibleTags = useMemo(() => {
-    if (!tagCategories || !enabledCategories || enabledCategories.size === 0) return []
-    const tagToCat = tagCategories.tag_to_category || {}
-    return availableTags.filter(({ tag }) => enabledCategories.has(tagToCat[tag]))
-  }, [availableTags, enabledCategories, tagCategories])
-
-  // Ordered category list for the pills row, sorted alphabetically by label.
-  const categoryEntries = useMemo(() => {
-    if (!tagCategories?.categories) return []
-    return Object.entries(tagCategories.categories)
-      .map(([id, c]) => ({ id, label: c.label, color: c.color }))
-      .sort((a, b) => a.label.localeCompare(b.label))
-  }, [tagCategories])
-
-  // Features matching the expanded tag
   const poisForTag = useMemo(() => {
     if (!expandedTag || !poiFeatures) return []
     return poiFeatures.filter(f => {
@@ -44,23 +40,19 @@ export default function POISearch({ availableTags, activeFilters, poiFeatures, e
     }).sort((a, b) => (a.properties.name || '').localeCompare(b.properties.name || ''))
   }, [expandedTag, poiFeatures])
 
-  // Scroll highlighted POI into view
   useEffect(() => {
     if (!poiListRef.current) return
     const items = poiListRef.current.querySelectorAll('[data-poi-item]')
     items[poiHighlightIdx]?.scrollIntoView({ block: 'nearest' })
   }, [poiHighlightIdx])
 
-  // Filter available tags by search query, excluding already-active filters.
-  // Source list is restricted to tags whose category is currently enabled.
-  // When query is empty, show top tags so arrow-key browsing works on focus.
   const matches = useMemo(() => {
-    const filtered = visibleTags.filter(({ tag }) => !activeFilters.has(tag))
+    const filtered = availableTags.filter(({ tag }) => !activeFilters.has(tag))
     if (!query.trim()) return filtered.slice(0, 8)
     return filtered
       .filter(({ tag }) => tag.includes(query.trim().toLowerCase()))
       .slice(0, 8)
-  }, [query, visibleTags, activeFilters])
+  }, [query, availableTags, activeFilters])
 
   const handleSelect = useCallback((tag) => {
     onAddFilter(tag)
@@ -137,7 +129,6 @@ export default function POISearch({ availableTags, activeFilters, poiFeatures, e
     }
   }, [poisForTag, poiHighlightIdx, onPoiSelect, onExpandTag])
 
-  // Close dropdown on outside click
   useEffect(() => {
     const handleClick = (e) => {
       if (containerRef.current && !containerRef.current.contains(e.target)) {
@@ -149,30 +140,11 @@ export default function POISearch({ availableTags, activeFilters, poiFeatures, e
     return () => document.removeEventListener('mousedown', handleClick)
   }, [onExpandTag])
 
+  const activeTagList = [...activeFilters]
+  const hasAnyPills = (mainCategories?.length ?? 0) > 0 || activeTagList.length > 0
+
   return (
     <div className="poi-search" ref={containerRef}>
-      {categoryEntries.length > 0 && (
-        <div className="poi-cat-pills">
-          {categoryEntries.map(({ id, label, color }) => {
-            const enabled = enabledCategories?.has(id)
-            return (
-              <button
-                key={id}
-                type="button"
-                className={`poi-cat-pill ${enabled ? 'enabled' : 'disabled'}`}
-                style={{
-                  borderColor: color,
-                  background: enabled ? color + '22' : 'transparent',
-                  color: enabled ? color : color + '99',
-                }}
-                onClick={() => onToggleCategory?.(id)}
-              >
-                {label}
-              </button>
-            )
-          })}
-        </div>
-      )}
       <div className="poi-search-input-row">
         <svg className="poi-search-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
           <circle cx="6.5" cy="6.5" r="5" stroke="currentColor" strokeWidth="1.5"/>
@@ -207,23 +179,72 @@ export default function POISearch({ availableTags, activeFilters, poiFeatures, e
         </div>
       )}
 
-      {activeFilters.size > 0 && (
-        <div className="poi-chips">
-          {[...activeFilters].map(tag => (
-            <div key={tag} className="poi-chip"
-              style={tagColors[tag] ? { borderColor: tagColors[tag] + '40', color: tagColors[tag] } : undefined}
-            >
-              <span className="poi-chip-text" onClick={(e) => handleTagTextClick(tag, e)}>{tag}</span>
-              {tagCounts[tag] != null && <span className="poi-chip-count" onClick={(e) => handleTagTextClick(tag, e)}>{tagCounts[tag]}</span>}
-              <span className="legend-filter-remove" onClick={(e) => handleRemoveTag(tag, e)}>
-                <svg width="8" height="8" viewBox="0 0 8 8">
-                  <path d="M1.5 1.5l5 5M6.5 1.5l-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-                </svg>
+      {hasAnyPills && (
+        <div className="poi-cat-pills">
+          {mainCategories?.map(({ id, label, color }) => {
+            const enabled = enabledCategories?.has(id)
+            return (
+              <button
+                key={`main:${id}`}
+                type="button"
+                className={`poi-cat-pill ${enabled ? 'enabled' : 'disabled'}`}
+                style={{
+                  borderColor: color,
+                  background: enabled ? color + '22' : 'transparent',
+                  color: enabled ? color : color + '99',
+                }}
+                onClick={() => onToggleCategory?.(id)}
+              >
+                {label}
+              </button>
+            )
+          })}
+
+          {activeTagList.map(tag => {
+            const color = tagColors[tag] || '#666'
+            const count = tagCounts[tag]
+            const present = count != null && count > 0
+            const stateClass = present ? 'enabled' : 'disabled'
+            return (
+              <span
+                key={`tag:${tag}`}
+                className={`poi-cat-pill poi-cat-pill-tag ${stateClass}`}
+                style={{
+                  borderColor: color,
+                  background: present ? color + '22' : 'transparent',
+                  color: present ? color : color + '99',
+                }}
+              >
+                <span
+                  className="poi-cat-pill-text"
+                  onClick={(e) => handleTagTextClick(tag, e)}
+                >
+                  {tag}
+                </span>
+                {count != null && (
+                  <span
+                    className="poi-cat-pill-count"
+                    onClick={(e) => handleTagTextClick(tag, e)}
+                  >
+                    {count}
+                  </span>
+                )}
+                <span
+                  className="poi-cat-pill-remove"
+                  onClick={(e) => handleRemoveTag(tag, e)}
+                  role="button"
+                  aria-label={`Remove ${tag}`}
+                >
+                  <svg width="8" height="8" viewBox="0 0 8 8">
+                    <path d="M1.5 1.5l5 5M6.5 1.5l-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                  </svg>
+                </span>
               </span>
-            </div>
-          ))}
-          {activeFilters.size >= 2 && (
-            <button className="poi-chip poi-chip-clear" onClick={onClearFilters}>
+            )
+          })}
+
+          {(activeFilters.size + (enabledCategories?.size ?? 0)) >= 2 && (
+            <button className="poi-cat-pill poi-cat-pill-clear" onClick={onClearFilters}>
               clear all
             </button>
           )}

--- a/src/POISearch.jsx
+++ b/src/POISearch.jsx
@@ -190,7 +190,7 @@ export default function POISearch({
                 className={`poi-cat-pill ${enabled ? 'enabled' : 'disabled'}`}
                 style={{
                   borderColor: color,
-                  background: enabled ? color + '22' : 'transparent',
+                  background: enabled ? color + '40' : 'transparent',
                   color: enabled ? color : color + '99',
                 }}
                 onClick={() => onToggleCategory?.(id)}
@@ -202,8 +202,8 @@ export default function POISearch({
 
           {activeTagList.map(tag => {
             const color = tagColors[tag] || '#666'
-            const count = tagCounts[tag]
-            const present = count != null && count > 0
+            const count = tagCounts[tag] ?? 0
+            const present = count > 0
             const stateClass = present ? 'enabled' : 'disabled'
             return (
               <span
@@ -211,7 +211,7 @@ export default function POISearch({
                 className={`poi-cat-pill poi-cat-pill-tag ${stateClass}`}
                 style={{
                   borderColor: color,
-                  background: present ? color + '22' : 'transparent',
+                  background: present ? color + '40' : 'transparent',
                   color: present ? color : color + '99',
                 }}
               >
@@ -221,14 +221,12 @@ export default function POISearch({
                 >
                   {tag}
                 </span>
-                {count != null && (
-                  <span
-                    className="poi-cat-pill-count"
-                    onClick={(e) => handleTagTextClick(tag, e)}
-                  >
-                    {count}
-                  </span>
-                )}
+                <span
+                  className="poi-cat-pill-count"
+                  onClick={(e) => handleTagTextClick(tag, e)}
+                >
+                  {count}
+                </span>
                 <span
                   className="poi-cat-pill-remove"
                   onClick={(e) => handleRemoveTag(tag, e)}

--- a/src/POISearch.jsx
+++ b/src/POISearch.jsx
@@ -190,8 +190,8 @@ export default function POISearch({
                 className={`poi-cat-pill ${enabled ? 'enabled' : 'disabled'}`}
                 style={{
                   borderColor: color,
-                  background: enabled ? color + '40' : 'transparent',
-                  color: enabled ? color : color + '99',
+                  background: enabled ? color : color + '40',
+                  color: enabled ? '#fff' : color,
                 }}
                 onClick={() => onToggleCategory?.(id)}
               >
@@ -211,8 +211,8 @@ export default function POISearch({
                 className={`poi-cat-pill poi-cat-pill-tag ${stateClass}`}
                 style={{
                   borderColor: color,
-                  background: present ? color + '40' : 'transparent',
-                  color: present ? color : color + '99',
+                  background: present ? color : color + '40',
+                  color: present ? '#fff' : color,
                 }}
               >
                 <span

--- a/src/Walksheds.jsx
+++ b/src/Walksheds.jsx
@@ -1,9 +1,9 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { buildGraph, isJunction, getJunctionHints } from './routeGraph'
 import { fetchWalkshed, getLargestEnabledBounds } from './mapbox'
-import { WALKSHED_OPTIONS, LINE_COLORS, WALKSHED_ACCENT_LIGHT, WALKSHED_ACCENT_DARK, SEATTLE_CENTER, SEATTLE_ZOOM, POI_FILES } from './constants'
+import { WALKSHED_OPTIONS, LINE_COLORS, WALKSHED_ACCENT_LIGHT, WALKSHED_ACCENT_DARK, SEATTLE_CENTER, SEATTLE_ZOOM, POI_FILES, MAIN_POI_CATEGORIES } from './constants'
 import { parseStationPath, buildStationPath, findStationByCode, parseWalkshedParams, buildWalkshedParams } from './deepLink'
-import { filterPOIsInWalkshed, filterByCategoriesOrTags, getAvailableTags, mergeFeatureCollections } from './poiUtils'
+import { filterPOIsInWalkshed, filterByMainCategoriesAndTags, getAvailableTags, mergeFeatureCollections } from './poiUtils'
 import { useNavigation } from './useNavigation'
 import MapView from './MapView'
 import LineLegend from './LineLegend'
@@ -233,15 +233,21 @@ export default function Walksheds() {
     [walkshedPois, tagColors],
   )
 
+  const mainCategoriesById = useMemo(() => {
+    const out = {}
+    for (const c of MAIN_POI_CATEGORIES) out[c.id] = c
+    return out
+  }, [])
+
   const visiblePois = useMemo(() => {
-    const filtered = filterByCategoriesOrTags(
+    const filtered = filterByMainCategoriesAndTags(
       walkshedPois.features,
       enabledCategories,
       poiFilters,
-      tagCategories?.tag_to_category,
+      mainCategoriesById,
     )
     return { type: 'FeatureCollection', features: filtered }
-  }, [walkshedPois, enabledCategories, poiFilters, tagCategories])
+  }, [walkshedPois, enabledCategories, poiFilters, mainCategoriesById])
 
   const handleToggleCategory = useCallback((catId) => {
     setEnabledCategories(prev => {
@@ -275,6 +281,7 @@ export default function Walksheds() {
 
   const handleClearPoiFilters = useCallback(() => {
     setPoiFilters(new Set())
+    setEnabledCategories(new Set())
     fitToWalkshed()
   }, [fitToWalkshed])
 
@@ -405,7 +412,7 @@ export default function Walksheds() {
           onRemoveFilter={handleRemovePoiFilter}
           onClearFilters={handleClearPoiFilters}
           onPoiSelect={handlePoiSelect}
-          tagCategories={tagCategories}
+          mainCategories={MAIN_POI_CATEGORIES}
           enabledCategories={enabledCategories}
           onToggleCategory={handleToggleCategory}
         />

--- a/src/__tests__/poiUtils.test.js
+++ b/src/__tests__/poiUtils.test.js
@@ -4,7 +4,7 @@ import {
   filterPOIsInWalkshed,
   getAvailableTags,
   filterByTags,
-  filterByCategoriesOrTags,
+  filterByMainCategoriesAndTags,
   mergeFeatureCollections,
 } from '../poiUtils'
 
@@ -203,67 +203,81 @@ describe('filterByTags', () => {
   })
 })
 
-describe('filterByCategoriesOrTags', () => {
+describe('filterByMainCategoriesAndTags', () => {
   const features = [
-    makeFeature(0, 0, { tags: ['pizza', 'italian'] }),       // cuisine
-    makeFeature(0, 0, { tags: ['sushi', 'japanese'] }),      // cuisine
-    makeFeature(0, 0, { tags: ['takeaway', 'wifi'] }),       // service + vibe
-    makeFeature(0, 0, { tags: ['vegetarian'] }),             // diet
-    makeFeature(0, 0, { tags: [] }),                         // none
+    makeFeature(0, 0, { category: 'restaurant', tags: ['pizza', 'italian'] }),
+    makeFeature(0, 0, { category: 'fast_food', tags: ['burger'] }),
+    makeFeature(0, 0, { category: 'cafe',       tags: ['wifi'] }),
+    makeFeature(0, 0, { category: 'bar',        tags: ['outdoor-seating'] }),
+    makeFeature(0, 0, { category: 'restaurant', tags: ['brewery'] }),
+    makeFeature(0, 0, { category: 'park',       tags: [] }),
+    makeFeature(0, 0, { category: 'museum',     tags: ['art'] }),
   ]
-  const tagToCategory = {
-    pizza: 'cuisine', italian: 'cuisine', sushi: 'cuisine', japanese: 'cuisine',
-    takeaway: 'service', wifi: 'vibe', vegetarian: 'diet',
+  const mainCategoriesById = {
+    restaurants: { matchCategories: ['restaurant', 'fast_food', 'ice_cream', 'bakery'], matchTags: [] },
+    bars:        { matchCategories: ['bar', 'pub'], matchTags: ['brewery', 'winery', 'distillery', 'has-bar'] },
+    coffee:      { matchCategories: ['cafe'], matchTags: ['coffee', 'coffee-shop', 'coffee-roaster'] },
+    parks:       { matchCategories: ['park', 'playground', 'garden'], matchTags: [] },
   }
 
   it('returns empty array when nothing is enabled or active', () => {
-    expect(filterByCategoriesOrTags(features, new Set(), new Set(), tagToCategory)).toEqual([])
-    expect(filterByCategoriesOrTags(features, null, null, tagToCategory)).toEqual([])
+    expect(filterByMainCategoriesAndTags(features, new Set(), new Set(), mainCategoriesById)).toEqual([])
+    expect(filterByMainCategoriesAndTags(features, null, null, mainCategoriesById)).toEqual([])
   })
 
-  it('matches features whose tag belongs to an enabled category', () => {
-    const result = filterByCategoriesOrTags(
-      features, new Set(['cuisine']), new Set(), tagToCategory,
+  it('matches features whose category is in an enabled main pill', () => {
+    const result = filterByMainCategoriesAndTags(
+      features, new Set(['restaurants']), new Set(), mainCategoriesById,
     )
-    expect(result).toHaveLength(2) // pizza + sushi POIs
+    // restaurant pizza + fast_food burger + restaurant brewery
+    expect(result).toHaveLength(3)
   })
 
-  it('matches features by active tag filter alone', () => {
-    const result = filterByCategoriesOrTags(
-      features, new Set(), new Set(['wifi']), tagToCategory,
+  it('matches features by main pill tag list (e.g. brewery → bars)', () => {
+    const result = filterByMainCategoriesAndTags(
+      features, new Set(['bars']), new Set(), mainCategoriesById,
     )
-    expect(result).toHaveLength(1) // takeaway+wifi POI
-  })
-
-  it('unions categories and active tags (additive)', () => {
-    // diet category enabled + sushi tag filter → vegetarian POI + sushi POI
-    const result = filterByCategoriesOrTags(
-      features, new Set(['diet']), new Set(['sushi']), tagToCategory,
-    )
+    // bar outdoor-seating + restaurant brewery (matched by tag)
     expect(result).toHaveLength(2)
   })
 
-  it('multiple enabled categories OR together', () => {
-    const result = filterByCategoriesOrTags(
-      features, new Set(['service', 'diet']), new Set(), tagToCategory,
+  it('matches by active tag filter alone', () => {
+    const result = filterByMainCategoriesAndTags(
+      features, new Set(), new Set(['wifi']), mainCategoriesById,
     )
-    expect(result).toHaveLength(2) // takeaway POI + vegetarian POI
+    expect(result).toHaveLength(1) // cafe wifi
   })
 
-  it('skips features with no tags array', () => {
-    const mixed = [...features, { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [0, 0] } }]
-    const result = filterByCategoriesOrTags(
-      mixed, new Set(['cuisine']), new Set(), tagToCategory,
+  it('unions main categories and active tags (additive)', () => {
+    const result = filterByMainCategoriesAndTags(
+      features, new Set(['parks']), new Set(['art']), mainCategoriesById,
     )
-    expect(result).toHaveLength(2) // unchanged
+    // park (no tags) + museum art tag
+    expect(result).toHaveLength(2)
   })
 
-  it('ignores tags whose category is not enabled', () => {
-    // wifi belongs to vibe; only enable cuisine → wifi POI excluded
-    const result = filterByCategoriesOrTags(
-      features, new Set(['cuisine']), new Set(), tagToCategory,
+  it('multiple enabled main categories OR together', () => {
+    const result = filterByMainCategoriesAndTags(
+      features, new Set(['coffee', 'parks']), new Set(), mainCategoriesById,
     )
-    expect(result.every(f => f.properties.tags.some(t => tagToCategory[t] === 'cuisine'))).toBe(true)
+    // cafe wifi + park
+    expect(result).toHaveLength(2)
+  })
+
+  it('handles features with no tags array', () => {
+    const mixed = [...features, { type: 'Feature', properties: { category: 'restaurant' }, geometry: { type: 'Point', coordinates: [0, 0] } }]
+    const result = filterByMainCategoriesAndTags(
+      mixed, new Set(['restaurants']), new Set(), mainCategoriesById,
+    )
+    expect(result).toHaveLength(4)
+  })
+
+  it('ignores categories not enabled', () => {
+    // only restaurants → museum, park, cafe, bar excluded
+    const result = filterByMainCategoriesAndTags(
+      features, new Set(['restaurants']), new Set(), mainCategoriesById,
+    )
+    expect(result.every(f => ['restaurant', 'fast_food'].includes(f.properties.category))).toBe(true)
   })
 })
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -76,4 +76,37 @@ export const POI_FILES = [
   'lodging', 'shopping', 'healthcare', 'services', 'fitness',
 ]
 
+// Always-visible main category toggles. Each pill matches POIs by raw OSM
+// `properties.category` value and/or by `properties.tags` membership.
+export const MAIN_POI_CATEGORIES = [
+  {
+    id: 'restaurants',
+    label: 'restaurants',
+    color: '#E67E22',
+    matchCategories: ['restaurant', 'fast_food', 'ice_cream', 'bakery'],
+    matchTags: [],
+  },
+  {
+    id: 'bars',
+    label: 'bars',
+    color: '#9B59B6',
+    matchCategories: ['bar', 'pub'],
+    matchTags: ['brewery', 'winery', 'distillery', 'has-bar'],
+  },
+  {
+    id: 'coffee',
+    label: 'coffee',
+    color: '#7B4A2A',
+    matchCategories: ['cafe'],
+    matchTags: ['coffee', 'coffee-shop', 'coffee-roaster'],
+  },
+  {
+    id: 'parks',
+    label: 'parks',
+    color: '#2ECC71',
+    matchCategories: ['park', 'playground', 'garden'],
+    matchTags: [],
+  },
+]
+
 export const POI_INTERACTIVE_LAYERS = ['poi-circles']

--- a/src/poiUtils.js
+++ b/src/poiUtils.js
@@ -82,29 +82,45 @@ export function filterByTags(features, activeTags) {
 }
 
 /**
- * Additive filter: a POI is visible if any of its tags is in an enabled
- * category OR any of its tags is in the active tag filters. With nothing
- * enabled and no active filters, returns an empty array (additive default).
+ * Additive filter: a POI is visible if it matches an enabled main category
+ * (by `properties.category` or by tag membership) OR if any of its tags is
+ * in the active tag filters. With nothing enabled and no active filters,
+ * returns an empty array (additive default).
  *
  * @param {Array} features - GeoJSON features
- * @param {Set<string>} enabledCategories - tag-category ids the user has activated
+ * @param {Set<string>} enabledMainIds - main-category ids the user has activated
  * @param {Set<string>} activeTags - explicit tag filters
- * @param {Object} [tagToCategory] - map from tag name → category id
+ * @param {Object} [mainCategoriesById] - map from id → { matchCategories[], matchTags[] }
  * @returns {Array} filtered features
  */
-export function filterByCategoriesOrTags(features, enabledCategories, activeTags, tagToCategory) {
-  const hasCats = enabledCategories && enabledCategories.size > 0
+export function filterByMainCategoriesAndTags(features, enabledMainIds, activeTags, mainCategoriesById) {
+  const hasMain = enabledMainIds && enabledMainIds.size > 0
   const hasTags = activeTags && activeTags.size > 0
-  if (!hasCats && !hasTags) return []
+  if (!hasMain && !hasTags) return []
+
+  const matchCats = new Set()
+  const matchMainTags = new Set()
+  if (hasMain && mainCategoriesById) {
+    for (const id of enabledMainIds) {
+      const cat = mainCategoriesById[id]
+      if (!cat) continue
+      for (const c of cat.matchCategories || []) matchCats.add(c)
+      for (const t of cat.matchTags || []) matchMainTags.add(t)
+    }
+  }
+
   return features.filter(f => {
-    const tags = f.properties?.tags
-    if (!Array.isArray(tags)) return false
-    if (hasCats && tagToCategory) {
-      for (const t of tags) {
-        if (enabledCategories.has(tagToCategory[t])) return true
+    const props = f.properties || {}
+    const tags = props.tags
+    if (hasMain) {
+      if (props.category && matchCats.has(props.category)) return true
+      if (Array.isArray(tags)) {
+        for (const t of tags) {
+          if (matchMainTags.has(t)) return true
+        }
       }
     }
-    if (hasTags) {
+    if (hasTags && Array.isArray(tags)) {
       for (const t of tags) {
         if (activeTags.has(t)) return true
       }

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -1088,16 +1088,16 @@ body,
   transition: opacity 0.1s, background 0.1s;
 }
 
-.poi-cat-pill.disabled {
-  opacity: 0.55;
-}
-
 .poi-cat-pill.disabled:hover {
-  opacity: 0.85;
+  filter: brightness(0.96);
 }
 
 .poi-cat-pill.enabled {
-  font-weight: 500;
+  font-weight: 600;
+}
+
+.poi-cat-pill.enabled:hover {
+  filter: brightness(1.06);
 }
 
 .poi-cat-pill-tag {
@@ -1133,6 +1133,14 @@ body,
 
 .poi-cat-pill-remove:hover {
   background: rgba(0, 0, 0, 0.18);
+}
+
+.poi-cat-pill.enabled .poi-cat-pill-remove {
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.poi-cat-pill.enabled .poi-cat-pill-remove:hover {
+  background: rgba(255, 255, 255, 0.45);
 }
 
 .app.dark .poi-cat-pill-remove {

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -843,59 +843,6 @@ body,
   color: rgba(255, 255, 255, 0.3);
 }
 
-/* ── POI Filter Chips ── */
-
-.poi-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 6px;
-}
-
-.poi-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  border: 1px solid rgba(0, 0, 0, 0.12);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(8px);
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 500;
-  color: #333;
-  cursor: pointer;
-  transition: background 0.15s ease;
-}
-
-.poi-chip:hover {
-  background: rgba(0, 0, 0, 0.06);
-}
-
-.app.dark .poi-chip {
-  background: rgba(20, 20, 30, 0.85);
-  border-color: rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.app.dark .poi-chip:hover {
-  background: rgba(255, 255, 255, 0.08);
-}
-
-.poi-chip-text {
-  max-width: 120px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.poi-chip-count {
-  opacity: 0.5;
-  font-size: 10px;
-  font-weight: 400;
-}
-
 /* ── POI list under search chips ── */
 
 .poi-chip-poi-list {
@@ -957,17 +904,6 @@ body,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.poi-chip-clear {
-  color: rgba(0, 0, 0, 0.4);
-  border-color: transparent;
-  background: transparent;
-  font-weight: 400;
-}
-
-.app.dark .poi-chip-clear {
-  color: rgba(255, 255, 255, 0.4);
 }
 
 /* ── POI Popup ── */
@@ -1127,19 +1063,20 @@ body,
   color: #5bb8f0;
 }
 
-/* ── POI category pills (sit above the search input) ── */
+/* ── POI category pills (sit under the search input) ── */
 
 .poi-cat-pills {
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
-  padding: 6px 8px 4px;
+  margin-top: 6px;
 }
 
 .poi-cat-pill {
   display: inline-flex;
   align-items: center;
-  height: 20px;
+  gap: 4px;
+  height: 22px;
   padding: 0 8px;
   border-radius: 999px;
   border: 1px solid;
@@ -1161,6 +1098,69 @@ body,
 
 .poi-cat-pill.enabled {
   font-weight: 500;
+}
+
+.poi-cat-pill-tag {
+  padding-right: 4px;
+}
+
+.poi-cat-pill-text {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.poi-cat-pill-count {
+  opacity: 0.6;
+  font-size: 10px;
+  font-weight: 400;
+}
+
+.poi-cat-pill-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.08);
+  color: inherit;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s ease;
+}
+
+.poi-cat-pill-remove:hover {
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.app.dark .poi-cat-pill-remove {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.app.dark .poi-cat-pill-remove:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.poi-cat-pill-clear {
+  border-color: transparent;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.4);
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.poi-cat-pill-clear:hover {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.app.dark .poi-cat-pill-clear {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.app.dark .poi-cat-pill-clear:hover {
+  color: rgba(255, 255, 255, 0.7);
 }
 
 /* ── Legend: POI filter tags ── */


### PR DESCRIPTION
Replace the 12-bucket alphabetical category row above the search input
with a sticky row of 4 macro-category pills (restaurants, bars, coffee,
parks) underneath the input. Active tag filters render in the same row
using the same pill style (.poi-cat-pill), unifying the previously
separate .poi-chip element.

Main pills now match POIs directly by raw OSM properties.category and
properties.tags (config in src/constants.js MAIN_POI_CATEGORIES) instead
of gating which sub-tags appear in the dropdown. The dropdown is
unrestricted: any tag in the walkshed shows up. Tag pills flip to the
disabled visual state when their count drops to 0 (e.g. carrying a
"burger" filter to a station with no burgers in range), but stay
present and removable.