### PR TITLE
Switch site to walksheds.xyz custom domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ playwright-report/
 *.tfstate
 *.tfstate.backup
 *.tfvars
+!*.tfvars.example
 
 # Processed transit data (regenerated from data/raw/)
 data/processed/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Per-feature properties on output GeoJSON: `id` (OSM node/way id), `name`, `categ
 
 ## Deployment
 
-React SPA deployed to GitHub Pages via `.github/workflows/deploy.yml` on push to main.
+React SPA deployed to GitHub Pages via `.github/workflows/deploy.yml` on push to main. Served from `https://walksheds.xyz` (custom domain). The domain binding lives in `public/CNAME` (Vite copies it into `dist/` at build time; GitHub Pages reads it on deploy). DNS for `walksheds.xyz` is managed in Cloudflare via the Terraform module in `infra/` — see `infra/README.md`.
 
 ### Pointing the live site at a PR branch
 

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.19.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:HkKPMZ/n+QiExkRUSLjGMTGnuIaph+k932LiTp7CKZM=",
+    "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
+    "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
+    "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
+    "zh:580786830d93e35b957754fd4c62d4681a3b19abc28b757e41acba26455663b1",
+    "zh:83c4bdfb0e74fd50e56fff3c461d76c1c1ec61af3f679e4de1aa70b5ed05a09f",
+    "zh:abb4d1052cee61d80f9cb51e5421e3c118312403afb7104b98bd7e310ac736ee",
+    "zh:b0aeeb3d66ea4d719989875e778c477065ba941e3a76e9a8caacc3be08208dd9",
+    "zh:e43b4b2dfcec1ce2115f5a5c86042d432deb49bee8eae103eb56d97ea02e2e3b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,30 +1,29 @@
 # infra/
 
-Terraform module managing Cloudflare DNS for `walksheds.xyz`. The site itself is hosted on GitHub Pages from the repo root; this module just wires the apex + `www` records to GitHub's edge.
+Terraform module managing Cloudflare DNS + TLS settings for `walksheds.xyz`. The site itself is hosted on GitHub Pages from the repo root; this module wires the apex + `www` records to GitHub's edge via CNAME flattening and forces HTTPS.
 
 ## One-time setup
 
 1. **Cloudflare zone**: add `walksheds.xyz` to your Cloudflare account and update the registrar's nameservers to the pair Cloudflare assigns. Wait for the zone to go "Active" in the dashboard.
-2. **API token**: https://dash.cloudflare.com/profile/api-tokens → *Create Token* → custom token with `Zone:DNS:Edit` scoped to `walksheds.xyz`.
-3. **Zone ID**: dashboard → `walksheds.xyz` → Overview → right sidebar.
-4. Copy `terraform.tfvars.example` to `terraform.tfvars` and fill in the two values. `terraform.tfvars` is gitignored.
+2. **API token**: https://dash.cloudflare.com/profile/api-tokens → *Create Token* → custom token with `Zone:DNS:Edit` + `Zone:Settings:Edit` scoped to `walksheds.xyz`.
+3. Copy `terraform.tfvars.example` to `terraform.tfvars` and paste the token in. `terraform.tfvars` is gitignored.
 
 ## Apply
 
 ```bash
 cd infra
 terraform init
-terraform plan    # expect 9 records to be added (4 A + 4 AAAA + 1 CNAME)
+terraform plan    # expect 5 records to be added (1 apex CNAME, 1 www CNAME, 3 zone settings)
 terraform apply
 ```
 
 ## What this creates
 
-- Four `A` records on `@` pointing at GitHub Pages' apex IPs.
-- Four `AAAA` records on `@` for IPv6.
-- One `CNAME` from `www` → `<github_pages_user>.github.io` so `www.walksheds.xyz` redirects via GitHub Pages.
+- `CNAME @ → tommyroar.github.io` (proxied — CNAME flattening at the apex).
+- `CNAME www → walksheds.xyz` (proxied).
+- Zone settings: `ssl = full`, `always_use_https = on`, `min_tls_version = 1.2`.
 
-All records are **DNS-only** (gray cloud). Proxying them through Cloudflare breaks GitHub Pages' Let's Encrypt provisioning for the custom domain. If you later want Cloudflare's CDN/analytics in front, switch SSL mode to *Full (strict)* first, then flip `proxied = true` here.
+Both DNS records are **proxied** (orange cloud). Cloudflare serves user-facing TLS via its Universal SSL cert; the `ssl = full` setting tells Cloudflare to re-encrypt to GitHub Pages' origin, which presents its own Let's Encrypt cert.
 
 ## State
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,31 @@
+# infra/
+
+Terraform module managing Cloudflare DNS for `walksheds.xyz`. The site itself is hosted on GitHub Pages from the repo root; this module just wires the apex + `www` records to GitHub's edge.
+
+## One-time setup
+
+1. **Cloudflare zone**: add `walksheds.xyz` to your Cloudflare account and update the registrar's nameservers to the pair Cloudflare assigns. Wait for the zone to go "Active" in the dashboard.
+2. **API token**: https://dash.cloudflare.com/profile/api-tokens → *Create Token* → custom token with `Zone:DNS:Edit` scoped to `walksheds.xyz`.
+3. **Zone ID**: dashboard → `walksheds.xyz` → Overview → right sidebar.
+4. Copy `terraform.tfvars.example` to `terraform.tfvars` and fill in the two values. `terraform.tfvars` is gitignored.
+
+## Apply
+
+```bash
+cd infra
+terraform init
+terraform plan    # expect 9 records to be added (4 A + 4 AAAA + 1 CNAME)
+terraform apply
+```
+
+## What this creates
+
+- Four `A` records on `@` pointing at GitHub Pages' apex IPs.
+- Four `AAAA` records on `@` for IPv6.
+- One `CNAME` from `www` → `<github_pages_user>.github.io` so `www.walksheds.xyz` redirects via GitHub Pages.
+
+All records are **DNS-only** (gray cloud). Proxying them through Cloudflare breaks GitHub Pages' Let's Encrypt provisioning for the custom domain. If you later want Cloudflare's CDN/analytics in front, switch SSL mode to *Full (strict)* first, then flip `proxied = true` here.
+
+## State
+
+State is stored locally (no remote backend). `*.tfstate*` is gitignored. The single-contributor zone doesn't justify a remote backend; revisit if that changes.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -2,49 +2,50 @@ provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
 
-# GitHub Pages apex IPs.
-# https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain
-locals {
-  github_pages_a_ips = [
-    "185.199.108.153",
-    "185.199.109.153",
-    "185.199.110.153",
-    "185.199.111.153",
-  ]
-  github_pages_aaaa_ips = [
-    "2606:50c0:8000::153",
-    "2606:50c0:8001::153",
-    "2606:50c0:8002::153",
-    "2606:50c0:8003::153",
-  ]
+# 1. Look up the existing Cloudflare Zone
+data "cloudflare_zone" "main" {
+  filter = {
+    name = var.domain_name
+  }
 }
 
-resource "cloudflare_record" "apex_a" {
-  for_each = toset(local.github_pages_a_ips)
-  zone_id  = var.zone_id
-  name     = "@"
-  type     = "A"
-  content  = each.value
-  # DNS-only so GitHub Pages can provision the Let's Encrypt cert for the apex.
-  proxied = false
-  ttl     = 1
-}
-
-resource "cloudflare_record" "apex_aaaa" {
-  for_each = toset(local.github_pages_aaaa_ips)
-  zone_id  = var.zone_id
-  name     = "@"
-  type     = "AAAA"
-  content  = each.value
-  proxied  = false
-  ttl      = 1
-}
-
-resource "cloudflare_record" "www_cname" {
-  zone_id = var.zone_id
-  name    = "www"
-  type    = "CNAME"
+# 2. Configure DNS for GitHub Pages.
+# Apex uses CNAME flattening (proxied) so Cloudflare serves the user-facing TLS
+# and forwards to GitHub Pages' edge. Origin TLS (CF → GH Pages) uses GH's own
+# Let's Encrypt cert + zone setting `ssl = full`.
+resource "cloudflare_dns_record" "apex" {
+  zone_id = data.cloudflare_zone.main.id
+  name    = "@"
   content = "${var.github_pages_user}.github.io"
-  proxied = false
+  type    = "CNAME"
+  proxied = true
   ttl     = 1
+}
+
+resource "cloudflare_dns_record" "www" {
+  zone_id = data.cloudflare_zone.main.id
+  name    = "www"
+  content = var.domain_name
+  type    = "CNAME"
+  proxied = true
+  ttl     = 1
+}
+
+# 3. HTTPS settings.
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = data.cloudflare_zone.main.id
+  setting_id = "ssl"
+  value      = "full"
+}
+
+resource "cloudflare_zone_setting" "always_use_https" {
+  zone_id    = data.cloudflare_zone.main.id
+  setting_id = "always_use_https"
+  value      = "on"
+}
+
+resource "cloudflare_zone_setting" "min_tls_version" {
+  zone_id    = data.cloudflare_zone.main.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,50 @@
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+# GitHub Pages apex IPs.
+# https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain
+locals {
+  github_pages_a_ips = [
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153",
+  ]
+  github_pages_aaaa_ips = [
+    "2606:50c0:8000::153",
+    "2606:50c0:8001::153",
+    "2606:50c0:8002::153",
+    "2606:50c0:8003::153",
+  ]
+}
+
+resource "cloudflare_record" "apex_a" {
+  for_each = toset(local.github_pages_a_ips)
+  zone_id  = var.zone_id
+  name     = "@"
+  type     = "A"
+  content  = each.value
+  # DNS-only so GitHub Pages can provision the Let's Encrypt cert for the apex.
+  proxied = false
+  ttl     = 1
+}
+
+resource "cloudflare_record" "apex_aaaa" {
+  for_each = toset(local.github_pages_aaaa_ips)
+  zone_id  = var.zone_id
+  name     = "@"
+  type     = "AAAA"
+  content  = each.value
+  proxied  = false
+  ttl      = 1
+}
+
+resource "cloudflare_record" "www_cname" {
+  zone_id = var.zone_id
+  name    = "www"
+  type    = "CNAME"
+  content = "${var.github_pages_user}.github.io"
+  proxied = false
+  ttl     = 1
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,3 @@
+# Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored.
+cloudflare_api_token = "REDACTED — create at https://dash.cloudflare.com/profile/api-tokens with Zone:DNS:Edit on walksheds.xyz"
+zone_id              = "REDACTED — Cloudflare dashboard → walksheds.xyz → Overview sidebar"

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,3 +1,2 @@
 # Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored.
-cloudflare_api_token = "REDACTED — create at https://dash.cloudflare.com/profile/api-tokens with Zone:DNS:Edit on walksheds.xyz"
-zone_id              = "REDACTED — Cloudflare dashboard → walksheds.xyz → Overview sidebar"
+cloudflare_api_token = "REDACTED — create at https://dash.cloudflare.com/profile/api-tokens with Zone:DNS:Edit + Zone:Settings:Edit on walksheds.xyz"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,16 +1,17 @@
 variable "cloudflare_api_token" {
+  description = "Cloudflare API token with Zone:DNS:Edit + Zone:Settings:Edit on walksheds.xyz."
   type        = string
   sensitive   = true
-  description = "Cloudflare API token with Zone:DNS:Edit on walksheds.xyz."
 }
 
-variable "zone_id" {
+variable "domain_name" {
+  description = "The domain name registered in Cloudflare."
   type        = string
-  description = "Cloudflare zone ID for walksheds.xyz (from CF dashboard sidebar)."
+  default     = "walksheds.xyz"
 }
 
 variable "github_pages_user" {
+  description = "Owner of the GitHub Pages repo; used as <user>.github.io target for the apex CNAME."
   type        = string
   default     = "tommyroar"
-  description = "Owner of the GitHub Pages repo; used as <user>.github.io target for the www CNAME."
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,16 @@
+variable "cloudflare_api_token" {
+  type        = string
+  sensitive   = true
+  description = "Cloudflare API token with Zone:DNS:Edit on walksheds.xyz."
+}
+
+variable "zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for walksheds.xyz (from CF dashboard sidebar)."
+}
+
+variable "github_pages_user" {
+  type        = string
+  default     = "tommyroar"
+  description = "Owner of the GitHub Pages repo; used as <user>.github.io target for the www CNAME."
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.40"
+    }
+  }
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,9 +1,10 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.0"
+
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.40"
+      version = "~> 5.0"
     }
   }
 }

--- a/public/404.html
+++ b/public/404.html
@@ -8,7 +8,7 @@
       var path = window.location.pathname;
       var search = window.location.search;
       window.location.replace(
-        '/walksheds/?p=' + encodeURIComponent(path) +
+        '/?p=' + encodeURIComponent(path) +
         (search ? '&' + search.slice(1) : '')
       );
     </script>

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+walksheds.xyz

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 import basicSsl from '@vitejs/plugin-basic-ssl'
 
 export default defineConfig({
-  base: '/walksheds/',
+  base: '/',
   plugins: [react(), basicSsl()],
   server: {
     port: 5187,


### PR DESCRIPTION
Adds public/CNAME so GitHub Pages binds walksheds.xyz on deploy, drops
the /walksheds/ Vite base path, and fixes the 404.html SPA redirect to
target the root. Cloudflare DNS for the apex + www CNAME is managed
in a new infra/ Terraform module (records DNS-only so GitHub Pages can
provision its Let's Encrypt cert).