### PR TITLE
Restore ANTHROPIC_API_KEY input on the @claude action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,5 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"


### PR DESCRIPTION
Fixes #44.

Commit [76b7ad3](https://github.com/tommyroar/walksheds/commit/76b7ad3e5c147e3d673bb30a9f50cda64e11b814) removed the `anthropic_api_key` input from `.github/workflows/ci.yml` on the assumption that the Claude GitHub App's OAuth integration would provide credentials automatically. That isn't how `anthropics/claude-code-action@v1` works — per its [`action.yml`](https://github.com/anthropics/claude-code-action/blob/main/action.yml), the action still needs an explicit auth input (`anthropic_api_key`, `claude_code_oauth_token`, or a cloud-provider OIDC config). The bot still posts its placeholder "I'll analyze this…" comment because that step runs before auth; the action then errors out when it tries to call the Anthropic API — visible on [run 26083301035](https://github.com/tommyroar/walksheds/actions/runs/26083301035) as "Claude encountered an error".

## Test plan

- [ ] Merge to main.
- [ ] Re-comment `@claude` on issue #44 (or any other open issue/PR) and confirm the workflow run completes with an actual response instead of the placeholder being edited to "Claude encountered an error".

If the `ANTHROPIC_API_KEY` repo secret has been deleted since 76b7ad3, the input should instead be `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` paired with the OAuth secret generated from the Claude GitHub App settings.

https://claude.ai/code/session_01BJfRR196Lb954yx5ttjYH3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJfRR196Lb954yx5ttjYH3)_