### PR TITLE
Update share title and legend heading per issue #44

### DIFF
--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -17,7 +17,7 @@ test.describe('Smoke tests', () => {
     const legend = page.locator('.line-legend')
     await expect(legend).toBeVisible({ timeout: 10000 })
     const title = page.locator('.legend-title').first()
-    await expect(title).toHaveText('Link light rail')
+    await expect(title).toHaveText('Legend')
   })
 
   test('legend has walkshed toggles', async ({ page }) => {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Architects+Daughter&display=swap" rel="stylesheet" />
-    <title>Walksheds — Seattle Light Rail Explorer</title>
+    <title>Walksheds — Transit Walkshed Navigator</title>
   </head>
   <body>
     <script>

--- a/src/LineLegend.jsx
+++ b/src/LineLegend.jsx
@@ -143,7 +143,7 @@ export default function LineLegend({
         <button className="legend-header-btn" onClick={onHintsToggle} aria-label="Toggle hints">
           {HELP_ICON}
         </button>
-        <h3 className="legend-title">Link light rail</h3>
+        <h3 className="legend-title">Legend</h3>
         <button className="legend-header-btn" onClick={onToggleCollapse} aria-label="Collapse legend">
           <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
             <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>


### PR DESCRIPTION
Fixes #44.

Two text updates:

- **Share-sheet / page title** (`index.html`): "Walksheds — Seattle Light Rail Explorer" → "Walksheds — Transit Walkshed Navigator". This is what iOS Safari surfaces in the share sheet and what tab-switchers / link previews use.
- **Legend heading** (`src/LineLegend.jsx`): "Link light rail" → "Legend". The `.legend-title` CSS rule already applies `text-transform: uppercase`, so this renders as "LEGEND".
- Updated the Playwright smoke test (`e2e/smoke.spec.js`) that asserted on the old legend title text.

187 unit tests + lint + build all pass locally.

## Test plan

- [ ] Open the deployed preview, confirm the legend reads "LEGEND" instead of "LINK LIGHT RAIL".
- [ ] Tap the share button on iOS Safari (or check the document title); confirm it surfaces "Walksheds — Transit Walkshed Navigator".

https://claude.ai/code/session_01BJfRR196Lb954yx5ttjYH3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJfRR196Lb954yx5ttjYH3)_