### PR TITLE
Fix hint overlay rough edges per issue #45

### DIFF
--- a/src/HintOverlay.jsx
+++ b/src/HintOverlay.jsx
@@ -2,8 +2,9 @@
 // input, the category pills, and the attribute-filter checkbox list.
 // The overlay itself is pointer-events: none; clicks anywhere on the
 // page dismiss it via a document-level listener in Walksheds.jsx.
-// `hasActiveFilters` suppresses the filter hint when the checkbox list
-// isn't rendered, so the arrow never points at empty space.
+// The filter hint renders dimmed when no attribute filters are active
+// (so the user still learns where filters will live), and switches to
+// full opacity + "uncheck to drop" copy once a filter exists.
 
 // Hand-drawn SVG arrows. The wobbly bezier curves and rounded line caps
 // mirror the imperfect strokes of the Architects Daughter font; sized to
@@ -99,14 +100,14 @@ export default function HintOverlay({ legendPosition, legendCollapsed, hasActive
         </span>
       </div>
 
-      {hasActiveFilters && (
-        <div className="hint hint-filters">
-          <span className="hint-label">
-            uncheck to drop an attribute filter
-            <ArrowRight />
-          </span>
-        </div>
-      )}
+      <div className={`hint hint-filters${hasActiveFilters ? '' : ' dimmed'}`}>
+        <span className="hint-label">
+          {hasActiveFilters
+            ? 'uncheck to drop an attribute filter'
+            : "filter by attribute — add tags from a chip's list"}
+          <ArrowRight />
+        </span>
+      </div>
     </div>
   )
 }

--- a/src/LineLegend.jsx
+++ b/src/LineLegend.jsx
@@ -113,7 +113,7 @@ export default function LineLegend({
             })}
           </div>
         <div className="legend-collapsed-divider" />
-        <button className="legend-expand-btn" onClick={onToggleCollapse} aria-label="Expand legend">
+        <button className="legend-expand-btn" onClick={onToggleCollapse} aria-label="Expand legend" data-hint-keep="true">
           <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
             <path d="M4 10l4-4 4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
@@ -144,7 +144,7 @@ export default function LineLegend({
           {HELP_ICON}
         </button>
         <h3 className="legend-title">Legend</h3>
-        <button className="legend-header-btn" onClick={onToggleCollapse} aria-label="Collapse legend">
+        <button className="legend-header-btn" onClick={onToggleCollapse} aria-label="Collapse legend" data-hint-keep="true">
           <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
             <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>

--- a/src/Walksheds.jsx
+++ b/src/Walksheds.jsx
@@ -500,9 +500,10 @@ export default function Walksheds() {
   // Restore POI filter state from `?pois=` once the schema is loaded.
   // Splits the parsed tag set into categories vs filters by the tag's
   // category-bucket — backward-compatible with URLs minted before this split.
-  // When no `?pois=` is present, seed sandwich (category pill) + outdoor-seating
-  // (filter checkbox) so the empty-state landing on Westlake demonstrates both
-  // the pill row and the filter list, alongside the parks + coffee spotlights.
+  // When no `?pois=` is present, seed the sandwich category pill so the
+  // empty-state landing on Westlake demonstrates the pill row alongside
+  // the parks + coffee spotlights. Filter checkboxes are left empty —
+  // users discover them via the dimmed hint in the overlay.
   useEffect(() => {
     if (!tagCategories || poisResolvedRef.current) return
     poisResolvedRef.current = true
@@ -521,7 +522,6 @@ export default function Walksheds() {
         }
       } else {
         setActiveCategories(new Set(['sandwich']))
-        setActiveFilters(new Set(['outdoor-seating']))
       }
     })
   }, [tagCategories, isFilterTag])
@@ -550,13 +550,16 @@ export default function Walksheds() {
 
   // Dismiss hints on any click. Armed after a short delay so the auto-fly
   // into Westlake (and any synthetic map events around it) doesn't swallow
-  // the hints on first paint.
+  // the hints on first paint. Elements marked `data-hint-keep` (the legend
+  // collapse/expand chevrons) are opted out so toggling the legend doesn't
+  // dismiss the hint that points at it.
   useEffect(() => {
     if (!hintsVisible) return
     let armed = false
     const armT = setTimeout(() => { armed = true }, 250)
-    const onClick = () => {
+    const onClick = (e) => {
       if (!armed) return
+      if (e.target?.closest?.('[data-hint-keep]')) return
       markHintsSeen()
       setHintsVisible(false)
     }

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -610,8 +610,10 @@ body,
   color: inherit;
   padding: 4px 10px;
   border-radius: 10px;
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+}
+
+.hint.dimmed {
+  opacity: 0.45;
 }
 
 /* Hand-drawn SVG arrows inline with the label text. Sized to match the


### PR DESCRIPTION
- Drop backdrop-filter blur on .hint-label so the hand-drawn labels read
  as ink on the map instead of a glass card.
- Keep hints visible when the user toggles the legend collapse/expand
  chevrons: opt them out of the document-level click dismisser via
  data-hint-keep, so the legend hint stays on screen while the user
  explores the panel it points at.
- Stop seeding the outdoor-seating attribute filter by default; instead
  always render the filter hint (dimmed, with empty-state copy) so the
  feature stays discoverable without forcing a preselection.