### PR TITLE
Add swipe-between-stations hint with dynamic next-station label

### DIFF
--- a/src/HintOverlay.jsx
+++ b/src/HintOverlay.jsx
@@ -11,10 +11,10 @@
 // match the cap-height of 18-19px text so each arrow reads as part of
 // the sentence flow.
 
-function ArrowRight() {
+function ArrowRight({ flip = false }) {
   return (
     <svg
-      className="hint-arrow hint-arrow-right"
+      className={`hint-arrow hint-arrow-right${flip ? ' flip' : ''}`}
       viewBox="0 0 44 18"
       width="44"
       height="18"
@@ -40,10 +40,10 @@ function ArrowRight() {
   )
 }
 
-function ArrowDown() {
+function ArrowDown({ flip = false }) {
   return (
     <svg
-      className="hint-arrow hint-arrow-down"
+      className={`hint-arrow hint-arrow-down${flip ? ' flip' : ''}`}
       viewBox="0 0 22 40"
       width="22"
       height="40"
@@ -69,7 +69,30 @@ function ArrowDown() {
   )
 }
 
-export default function HintOverlay({ legendPosition, legendCollapsed, hasActiveFilters }) {
+// A touch swipe is the inverse of the travel direction — you drag the world
+// the opposite way, like panning a map. This mirrors the gesture mapping in
+// useNavigation.js (swipe up → ArrowDown, swipe down → ArrowUp, swipe left →
+// ArrowRight, swipe right → ArrowLeft), so the word + arrow the hint shows
+// match the finger motion that actually reaches the next station.
+const SWIPE_FOR_ARROW = {
+  ArrowUp: 'down',
+  ArrowDown: 'up',
+  ArrowLeft: 'right',
+  ArrowRight: 'left',
+}
+
+// Draw the swipe gesture's finger motion. Horizontal swipes reuse the wide
+// ArrowRight glyph (flipped for "left"); vertical swipes reuse the tall
+// ArrowDown glyph (flipped for "up"). Flipping is a 180° rotation, so the
+// SVG's layout box is unchanged and the arrow still flows inline with text.
+function SwipeArrow({ direction }) {
+  if (direction === 'left' || direction === 'right') {
+    return <ArrowRight flip={direction === 'left'} />
+  }
+  return <ArrowDown flip={direction === 'up'} />
+}
+
+export default function HintOverlay({ legendPosition, legendCollapsed, hasActiveFilters, swipeHint }) {
   const legendClass = [
     'hint',
     'hint-legend',
@@ -108,6 +131,15 @@ export default function HintOverlay({ legendPosition, legendCollapsed, hasActive
           <ArrowRight />
         </span>
       </div>
+
+      {swipeHint && (
+        <div className="hint hint-swipe">
+          <span className="hint-label">
+            swipe {SWIPE_FOR_ARROW[swipeHint.arrowKey]} to ride to {swipeHint.label}
+            <SwipeArrow direction={SWIPE_FOR_ARROW[swipeHint.arrowKey]} />
+          </span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/MapView.jsx
+++ b/src/MapView.jsx
@@ -26,6 +26,7 @@ const MapView = forwardRef(function MapView({
   onPoiTagClick,
   onPopupStationClick,
   onPopupFocus,
+  onUserInteract,
   units,
 }, ref) {
   const mapRef = useRef(null)
@@ -95,6 +96,16 @@ const MapView = forwardRef(function MapView({
       if (map.getLayer(id)) map.moveLayer(id)
     }
   }, [walksheds, enabledWalksheds, mapLoaded, iconsReady, darkMode])
+
+  // A user-initiated zoom (scroll-zoom, pinch, double-tap) carries an
+  // originalEvent; programmatic fitBounds/flyTo/easeTo do not. We key off zoom
+  // rather than move because a one-finger swipe pans the map (firing movestart)
+  // mid-gesture — keying off move would mark the view "touched" before the
+  // swipe's own touchend gets a chance to navigate. Zoom is the signal that the
+  // user has stopped riding the line and started inspecting a walkshed.
+  const handleZoomStart = useCallback((e) => {
+    if (e.originalEvent) onUserInteract?.()
+  }, [onUserInteract])
 
   const handleDragStart = useCallback(() => { isDraggingRef.current = true }, [])
   const handleDragEnd = useCallback(() => {
@@ -168,6 +179,7 @@ const MapView = forwardRef(function MapView({
       mapboxAccessToken={MAPBOX_TOKEN}
       interactiveLayerIds={mapLoaded ? ['station-circles', ...POI_INTERACTIVE_LAYERS] : []}
       onClick={handleMapClick}
+      onZoomStart={handleZoomStart}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onMouseEnter={handleMouseEnter}

--- a/src/Walksheds.jsx
+++ b/src/Walksheds.jsx
@@ -144,6 +144,11 @@ export default function Walksheds() {
   const [listOnTop, setListOnTop] = useState(false)
   const mapViewRef = useRef(null)
   const selectedStationRef = useRef(null)
+  // False right after a station is selected (map programmatically framed to its
+  // walkshed), flipped true once the user zooms in to inspect it. Lets swipes
+  // on a fresh station view navigate to the neighbor the hint promises instead
+  // of being eaten by the in-walkshed snap-back.
+  const userMovedSinceSelectRef = useRef(false)
   const graphRef = useRef(null)
   const resolvedRef = useRef(false)
   const poisResolvedRef = useRef(false)
@@ -189,6 +194,9 @@ export default function Walksheds() {
 
   const selectStation = useCallback((name, lng, lat, line) => {
     selectedStationRef.current = { name, lng, lat }
+    // A new selection re-frames the map programmatically; treat the view as
+    // "untouched" until the user zooms in again.
+    userMovedSinceSelectRef.current = false
     const feat = stationsData?.features.find(f => f.properties.name === name)
     const stopCode = feat?.properties.stopCode ?? null
     const lines = feat?.properties.lines ?? line.replace('-line', '')
@@ -423,6 +431,13 @@ export default function Walksheds() {
   // back to the top. Wired into POILayer's popup container.
   const handlePopupFocus = useCallback(() => setListOnTop(false), [])
 
+  // Mark the framed station view as "touched" once the user zooms in, so the
+  // swipe-to-navigate carve-out in handleScrollNavigationAttempt yields to the
+  // in-walkshed snap-back from then on (until the next selection re-frames).
+  const handleUserInteract = useCallback(() => {
+    userMovedSinceSelectRef.current = true
+  }, [])
+
   // Hand keyboard focus from the search box back to the map canvas so the
   // user can pan/zoom with arrow keys right after committing a selection.
   const focusMap = useCallback(() => {
@@ -438,6 +453,11 @@ export default function Walksheds() {
   const handleScrollNavigationAttempt = useCallback(() => {
     const map = mapViewRef.current?.getMap()
     if (!map) return true
+    // On a freshly-framed station view (the user hasn't zoomed in since
+    // selecting), let the swipe/scroll navigate to the adjacent station — this
+    // is the gesture the swipe hint teaches. Snap-back only applies once the
+    // user has zoomed in to explore. A POI popup still takes precedence.
+    if (!poiPopup && !userMovedSinceSelectRef.current) return true
     const center = map.getCenter()
     // Use the helper with poiPopup omitted so the target is always station
     // coords — the wheel snap goes to station regardless of popup state.
@@ -612,6 +632,7 @@ export default function Walksheds() {
         onPoiTagClick={handleAddPoiFilter}
         onPopupStationClick={handlePopupStationClick}
         onPopupFocus={handlePopupFocus}
+        onUserInteract={handleUserInteract}
         units={units}
       />
 

--- a/src/Walksheds.jsx
+++ b/src/Walksheds.jsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
-import { buildGraph, isJunction, getJunctionHints, getTerminusInfo } from './routeGraph'
+import { buildGraph, isJunction, getJunctionHints, getTerminusInfo, getSwipeHint } from './routeGraph'
 import { fetchWalkshed, getLargestEnabledBounds, computeSnapTarget } from './mapbox'
 import { WALKSHED_OPTIONS, LINE_COLORS, WALKSHED_ACCENT_LIGHT, POI_FILES, MAIN_POI_CATEGORIES, DEFAULT_ENABLED_MAIN_CATEGORIES } from './constants'
 import { parseStationPath, buildStationPath, findStationByCode, parseWalkshedParams, buildWalkshedParams, combineQuery } from './deepLink'
@@ -166,9 +166,14 @@ export default function Walksheds() {
       .then(d => { if (d) setTagCategories(d) })
   }, [])
 
+  // Build the adjacency graph once per stations payload. Kept both as a
+  // memoized value (for render-time reads like the swipe hint) and mirrored
+  // into graphRef so the navigation/selection event handlers can reach it
+  // without re-subscribing.
+  const graph = useMemo(() => (stationsData ? buildGraph(stationsData) : null), [stationsData])
   useEffect(() => {
-    if (stationsData) graphRef.current = buildGraph(stationsData)
-  }, [stationsData])
+    graphRef.current = graph
+  }, [graph])
 
   const handleWalkshedToggle = useCallback((minutes) => {
     const next = new Set(enabledWalksheds)
@@ -570,6 +575,14 @@ export default function Walksheds() {
     }
   }, [hintsVisible])
 
+  // Onward station for the swipe hint, recomputed whenever the selected
+  // station (popup) or current line changes so the label tracks the user as
+  // they ride along the line. Only needed while the hints are on screen.
+  const swipeHint = useMemo(() => {
+    if (!hintsVisible || !popup || !graph) return null
+    return getSwipeHint(graph, popup.name, currentLine)
+  }, [hintsVisible, popup, currentLine, graph])
+
   const handleHintsToggle = useCallback(() => {
     setHintsVisible(v => {
       const next = !v
@@ -643,6 +656,7 @@ export default function Walksheds() {
           legendPosition={legendPosition}
           legendCollapsed={legendCollapsed}
           hasActiveFilters={activeFilters.size > 0}
+          swipeHint={swipeHint}
         />
       )}
     </div>

--- a/src/__tests__/routeGraph.test.js
+++ b/src/__tests__/routeGraph.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildGraph, getNextStation, isJunction, getJunctionHints, getTerminusInfo } from '../routeGraph'
+import { buildGraph, getNextStation, isJunction, getJunctionHints, getTerminusInfo, getSwipeHint } from '../routeGraph'
 
 const mockStations = {
   type: 'FeatureCollection',
@@ -152,6 +152,35 @@ describe('routeGraph', () => {
 
     it('unknown stations return null', () => {
       expect(getTerminusInfo(graph, 'Not A Station')).toBeNull()
+    })
+  })
+
+  describe('getSwipeHint', () => {
+    it('points at the onward (toward-terminus) station on the current line', () => {
+      // Southbound from International District on Line 1 → Stadium.
+      const hint = getSwipeHint(graph, 'International District Station', '1-line')
+      expect(hint).toEqual({ stationName: 'Stadium Station', label: 'Stadium', arrowKey: 'ArrowDown' })
+    })
+
+    it('follows the current line through the junction', () => {
+      // Same station on Line 2 diverges east → Judkins Park.
+      const hint = getSwipeHint(graph, 'International District Station', '2-line')
+      expect(hint).toEqual({ stationName: 'Judkins Park Station', label: 'Judkins Park', arrowKey: 'ArrowRight' })
+    })
+
+    it('falls back to the prior station at a terminus', () => {
+      const hint = getSwipeHint(graph, 'Federal Way Downtown Station', '1-line')
+      expect(hint.stationName).toBe('Star Lake Station')
+      expect(hint.label).toBe('Star Lake')
+    })
+
+    it('defaults to Line 1 when no current line is set', () => {
+      const hint = getSwipeHint(graph, 'International District Station', null)
+      expect(hint.stationName).toBe('Stadium Station')
+    })
+
+    it('returns null for unknown stations', () => {
+      expect(getSwipeHint(graph, 'Not A Station', '1-line')).toBeNull()
     })
   })
 })

--- a/src/routeGraph.js
+++ b/src/routeGraph.js
@@ -227,6 +227,39 @@ export function getJunctionHints(graph, stationName) {
 }
 
 /**
+ * Pick a representative onward station for the swipe/keyboard hint, plus the
+ * cardinal arrow key that reaches it. Walks the current line's order toward
+ * the far terminus (the next index); at the terminus it falls back to the
+ * prior station so the hint always names a real, navigable neighbor. The
+ * arrowKey is derived from the actual bearing the same way getNextStation
+ * bins it, so the gesture the hint teaches is guaranteed to land on the
+ * returned station.
+ *
+ * Returns `{ stationName, label, arrowKey }`, or null when the station isn't
+ * on the current line (or the line has no neighbor to move to).
+ */
+export function getSwipeHint(graph, stationName, currentLine) {
+  if (!graph) return null
+  const order = currentLine === '2-line' ? LINE_2_ORDER : LINE_1_ORDER
+  const idx = order.indexOf(stationName)
+  if (idx === -1) return null
+
+  const targetName = idx < order.length - 1 ? order[idx + 1] : order[idx - 1]
+  if (!targetName) return null
+
+  const current = graph.get(stationName)
+  const target = graph.get(targetName)
+  if (!current || !target) return null
+
+  const b = bearing(current.coords[0], current.coords[1], target.coords[0], target.coords[1])
+  return {
+    stationName: targetName,
+    label: targetName.replace(' Station', ''),
+    arrowKey: nearestCardinal(b),
+  }
+}
+
+/**
  * Bin a bearing (0–360°) to the nearest cardinal arrow key. Ties (e.g. 45°
  * between Up and Right) resolve to whichever entry comes first in
  * ARROW_BEARINGS, which is Up → Right → Down → Left.

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -634,6 +634,12 @@ body,
   vertical-align: -10px;
 }
 
+/* Flipped variant: a 180° rotation reuses the same glyph (and its layout
+   box) for the opposite swipe direction — left from right, up from down. */
+.hint-arrow.flip {
+  transform: rotate(180deg);
+}
+
 /* Legend hint: card above the legend, ⤵ glyph inside the label points
    the user's eye down at the legend itself. */
 .hint-legend.bottom-left {
@@ -696,6 +702,21 @@ body,
 
 .hint-filters .hint-label {
   max-width: 440px;
+}
+
+/* Swipe hint: floats over the lower-center of the map, away from the
+   centered station pill and the bottom legend, naming the next stop you'd
+   reach by swiping. The arrow shows the finger motion (see SWIPE_FOR_ARROW
+   in HintOverlay.jsx), so it can point any direction inline with the text. */
+.hint-swipe {
+  left: 50%;
+  bottom: 26%;
+  transform: translateX(-50%);
+  text-align: center;
+}
+
+.hint-swipe .hint-label {
+  max-width: 300px;
 }
 
 /* Tablet / phone-landscape (640–1024px): same fixed search-column

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -731,6 +731,10 @@ body,
   .hint-filters .hint-label { max-width: 400px; }
   .hint-legend.bottom-left  { left: 14px; bottom: 300px; }
   .hint-legend.bottom-right { right: 14px; bottom: 300px; }
+  /* Pin to a fixed offset above the bottom legend instead of a percentage —
+     on short landscape phones 26% lands on top of the collapsed legend hint. */
+  .hint-swipe { bottom: 150px; }
+  .hint-swipe .hint-label { max-width: 260px; }
 }
 
 /* Phone portrait (< 540px): the search column shrinks to 180px and
@@ -747,6 +751,8 @@ body,
   .hint-legend.bottom-left  { left: 10px;  bottom: 280px; }
   .hint-legend.bottom-right { right: 10px; bottom: 280px; }
   .hint-arrow { font-size: 18px; }
+  .hint-swipe { bottom: 140px; }
+  .hint-swipe .hint-label { max-width: 200px; }
 }
 
 /* ── Mapbox overrides ── */


### PR DESCRIPTION
Surface the swipe gesture in the onboarding hint overlay. A new
lower-center hint names the next stop you'd reach by swiping ("swipe up
to ride to Symphony"), updating live as the selected station and current
line change — it follows the line through the International District
junction and falls back to the prior stop at a terminus.

- routeGraph: getSwipeHint() picks the onward (toward-terminus) station
  on the current line and the cardinal arrow that reaches it, derived
  from the real bearing so the taught gesture always lands on the named
  stop.
- HintOverlay: render the swipe hint; SWIPE_FOR_ARROW maps travel
  direction to the inverse finger motion (matching useNavigation), and a
  reused hand-drawn arrow (flipped 180°) shows the swipe direction.
- Walksheds: memoize the route graph (mirrored into graphRef for event
  handlers) and compute the swipe hint reactively from the selection.
- Tests cover onward selection, junction line-following, terminus
  fallback, line default, and unknown stations.