### PR TITLE
Live-site Playwright smoke + uptime workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,38 @@
+name: Live smoke
+
+# Probes the live site with Playwright. Its run conclusions + the github-pages
+# deployment_status events are ingested into InfluxDB by the host-side
+# walksheds-uptime collector (observability repo) and shown on the Grafana
+# uptime dashboard. schedule + deployment_status fire from the default branch
+# once merged; workflow_dispatch works on any branch.
+on:
+  schedule:
+    - cron: '*/30 * * * *'   # periodic uptime probe
+  deployment_status:          # probe right after a deploy
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Live smoke (walksheds.xyz)
+    # On deployment_status, only probe once a deploy actually succeeded.
+    if: ${{ github.event_name != 'deployment_status' || github.event.deployment_status.state == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm install
+
+      - run: npx playwright install --with-deps chromium
+
+      - name: Smoke the live site
+        run: npx playwright test e2e/uptime.spec.js --project=chromium
+        env:
+          BASE_URL: https://walksheds.xyz

--- a/e2e/uptime.spec.js
+++ b/e2e/uptime.spec.js
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test'
+
+// Minimal liveness probe consumed by the Grafana uptime dashboard. Kept small
+// and interaction-free on purpose: it answers "is the site serving and does the
+// map render?", not feature behavior (that's smoke.spec.js / hints.spec.js).
+test('site is up and the map renders', async ({ page }) => {
+  const res = await page.goto('/')
+  expect(res?.status()).toBe(200)
+  await expect(page).toHaveTitle(/Walksheds/)
+  await expect(page.locator('.mapboxgl-canvas')).toBeVisible({ timeout: 20000 })
+})


### PR DESCRIPTION
## What

A minimal Playwright liveness probe and a CI workflow that runs it against the live site, designed to feed the Grafana uptime dashboard.

- `e2e/uptime.spec.js` — interaction-free smoke: HTTP 200 + title + the Mapbox canvas renders. Deliberately small so it reflects "is the site serving", not feature behavior (that stays in `smoke.spec.js` / `hints.spec.js`).
- `.github/workflows/smoke.yml` — runs the probe against `https://walksheds.xyz` on a 30-min schedule, after each deploy (`deployment_status`, only on success), and on demand.

## How it feeds Grafana

CI can't reach the home InfluxDB (localhost/LAN/tailnet only), and the stack's convention is "CI hermetic, host collectors do live writes." So a host-side **walksheds-uptime collector** (in the observability repo) polls the GitHub API for this workflow's run conclusions + the `github-pages` deployment events, does its own synthetic probe for continuous uptime, and writes to the `ops` bucket (`service=walksheds`). The Grafana uptime dashboard reads that.

## Notes

- Verified locally: `BASE_URL=https://walksheds.xyz npx playwright test e2e/uptime.spec.js` passes against the live site.
- `schedule` / `deployment_status` / `workflow_dispatch` only register from the default branch, so the workflow activates on merge to `main`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>