### PR TITLE
ci: adopt the shared PR-newspaper gate

### DIFF
--- a/.github/workflows/pr-newspaper.yml
+++ b/.github/workflows/pr-newspaper.yml
@@ -1,0 +1,10 @@
+name: PR newspaper
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+jobs:
+  newspaper:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: tommyroar/pr-newspaper/.github/workflows/validate.yml@main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,3 +174,11 @@ Westlake (center) = 50. Numbers increase south/east, decrease north. Gaps reserv
 54=Judkins Park, 55=Mercer Island, 56=South Bellevue, 57=East Main, 58=Bellevue Downtown,
 59=Wilburton, 60=Spring District, 61=BelRed, 62=Overlake Village, 63=Redmond Technology,
 64=Marymoor Village, 65=Downtown Redmond
+## Pull requests — the "newspaper" framework
+
+PR descriptions follow the **newspaper / information-pyramid** format: one self-contained
+front page (kicker → headline → dek → masthead → why → what → mermaid flow → screens →
+verification → risk) that reads top-to-bottom on an iPad-mini portrait display (1–2 pages;
+up to 4 for very complex *code* changes). Rebuild from the **full** diff, never append.
+Full rules: <https://github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md>. CI validates
+the body via the `pr-newspaper` workflow (the reusable gate in `tommyroar/pr-newspaper`).


### PR DESCRIPTION
`CI` — **WORKFLOW DISPATCH**

# A newspaper gate for walksheds

> _PR descriptions here now validate against the shared newspaper framework — automatically, with no model in the loop._

> [!NOTE]
> **ci** · chore · risk: low

This wires `walksheds` into the account-wide PR "newspaper" framework. A small caller workflow invokes the shared reusable validator in `tommyroar/pr-newspaper`, which checks every PR body for readability and the iPad-mini page budget. Generation still happens once, by whoever opens the PR; this only enforces the shape.

## What changed
- `.github/workflows/pr-newspaper.yml` — calls the shared reusable `validate.yml` on opened/edited/reopened.
- A "newspaper" pointer added to `CLAUDE.md` so agents (incl. Claude Code web) follow the format.

## How it flows
```mermaid
flowchart TD
  A[PR opened/edited] --> B[caller workflow]
  B -->|uses:| C[tommyroar/pr-newspaper reusable]
  C --> D[validate_pr.py: readability + page budget]
  D -->|pass| E[green check]
  D -->|fail| F[fix the body]
```

## Verification
- This PR's own run exercises the gate end-to-end.

## Risk & rollout
- Validation triggers on opened/edited/reopened only — existing open PRs aren't retroactively blocked.
- Rollback: delete the caller workflow.