### PR TITLE
refactor: Match Link line colors to the official Sound Transit palette

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Walksheds — Seattle light rail walkshed explorer. Interactive React SPA showin
 
 ## Design & House Style
 
-This is a transit project; the visual language must look like real transit cartography — the classic stuff: Vignelli/Beck-lineage diagrams, clean line-colored routes, station roundels/pills, restrained sans-serif type, the established Link light rail palette (1 Line `#4CAF50`, 2 Line `#0082C8`). When adding or changing any UI, default to that idiom and reuse the existing station-pill / line-color vocabulary rather than inventing new ornament.
+This is a transit project; the visual language must look like real transit cartography — the classic stuff: Vignelli/Beck-lineage diagrams, clean line-colored routes, station roundels/pills, restrained sans-serif type, the official Sound Transit Link palette (1 Line `#38B030`, 2 Line `#00A0E0`). When adding or changing any UI, default to that idiom and reuse the existing station-pill / line-color vocabulary rather than inventing new ornament.
 
 **No emoji.** Do not use emoji anywhere — not in the UI, popups, labels, docs, wiki, commit messages, or PR descriptions. They are not the house style. Use real iconography (inline SVG, the station sprite drawer) or plain typographic marks instead.
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -22,12 +22,12 @@ export const WALKSHED_STYLES = {
 }
 
 export const LINE_COLORS = {
-  '1-line': { color: '#4CAF50', label: '1 Line' },
-  '2-line': { color: '#0082C8', label: '2 Line' },
+  '1-line': { color: '#38B030', label: '1 Line' },
+  '2-line': { color: '#00A0E0', label: '2 Line' },
 }
 
-export const WALKSHED_ACCENT_LIGHT = '#0082C8'
-export const WALKSHED_ACCENT_DARK = '#4CAF50'
+export const WALKSHED_ACCENT_LIGHT = '#00A0E0'
+export const WALKSHED_ACCENT_DARK = '#38B030'
 
 export const POI_CATEGORIES = {
   restaurant:      { color: '#E67E22', group: 'dining', label: 'Restaurant' },

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -1274,7 +1274,7 @@ body,
 }
 
 .poi-popup-info-link {
-  color: #0082C8;
+  color: #00A0E0;
   text-decoration: none;
   min-width: 0;
   overflow-wrap: anywhere;
@@ -1285,7 +1285,7 @@ body,
 }
 
 .app.dark .poi-popup-info-link {
-  color: #5bb8f0;
+  color: #4dc4f0;
 }
 
 /* "N more" / "less" toggle for tags and info rows. */


### PR DESCRIPTION
`BRAND` — **DESIGN DISPATCH**

# Match Link line colors to the official Sound Transit palette

> _The two Link line colors shipped as Material Design look-alikes. This swaps them — and the walkshed accent and popup links that trail them — for Sound Transit's real brand values, sampled from the agency's own service maps._

> [!NOTE]
> **area** design/brand · **type** refactor · **risk** low · pure constants + CSS, no logic

## Why

Walksheds has always drawn its routes in Material Design swatches — `#4CAF50` green, `#0082C8` blue — that read *close to*, but not the same as, Sound Transit's brand. Set the app beside any real ST surface (the system map, station signage, the wayfinding kit) and the mismatch shows: our green is a touch minty, our blue a touch dark. The official maps use a brighter, leafier green and a lighter cyan. This is the small, surgical fix that closes that gap.

## What changed

The single source of truth is `src/constants.js` — four values, no logic:

| Token | Before (Material) | After (official ST) | Δ |
| --- | --- | --- | --- |
| 1 Line | `#4CAF50` | `#38B030` | greener, less mint |
| 2 Line | `#0082C8` | `#00A0E0` | lighter, more cyan |
| `WALKSHED_ACCENT_LIGHT` | `#0082C8` | `#00A0E0` | follows 2 Line |
| `WALKSHED_ACCENT_DARK` | `#4CAF50` | `#38B030` | follows 1 Line |

Two trailing references caught in the same pass:

- **`src/walksheds.css`** — the POI popup `info-link` was hardcoded to the old 2 Line blue (`#0082C8`, dark `#5bb8f0`). Retinted to the new cyan (`#00A0E0`, dark `#4dc4f0`) so links stay visually tied to the line palette.
- **`CLAUDE.md`** — the house-style palette reference now quotes the official hexes.

> _Values sampled directly from Sound Transit's current and future service maps (soundtransit.org/get-to-know-us/maps)._

## How it flows

```mermaid
flowchart TD
  C[constants.js<br/>LINE_COLORS + WALKSHED_ACCENT_*]
  C --> P[StationPill / line roundels]
  C --> L[LineLegend + walkshed swatches]
  C --> W[WalkshedLayers<br/>isochrone fill + outline]
  X[walksheds.css<br/>.poi-popup-info-link] --> K[POI popup links]
```

## Verification

- [x] `npm run lint` — clean
- [x] `npm run test -- --run pillVisibility invariants` — 58 pass; **no pill-contrast regression**. The contrast audit (`src/pillColors.js`) benchmarks POI-group colors, not line colors, so it is structurally unaffected — and the run confirms it.
- [ ] `npm run e2e` — pill-visibility spec (the only local failures are the unrelated, localStorage-dependent hints-overlay specs)
- Visual: 1 Line reads greener; 2 Line lighter cyan; the isochrone accent follows 2 Line in light mode and 1 Line in dark.

## Risk & rollout

**Low.** No new API, no data, no logic — only color literals and one doc line. Blast radius is the line roundels, the legend, the walkshed accent, and POI popup links, all of which read from the changed constants/rule. Rollback is restoring the six hex values (or `git revert`).
