### PR TITLE
feat: render POI map markers as category glyph roundels

### DIFF
--- a/src/MapView.jsx
+++ b/src/MapView.jsx
@@ -110,7 +110,7 @@ const MapView = forwardRef(function MapView({
   useEffect(() => {
     const map = mapRef.current?.getMap()
     if (!map || !mapLoaded) return
-    for (const id of ['poi-circles', 'poi-labels', 'station-circles']) {
+    for (const id of ['poi-labels', 'station-circles']) {
       if (map.getLayer(id)) map.moveLayer(id)
     }
   }, [walksheds, enabledWalksheds, mapLoaded, iconsReady, darkMode, visiblePois])
@@ -163,6 +163,15 @@ const MapView = forwardRef(function MapView({
     suppressMapClickRef.current = true
     onExitClick?.(exit)
   }, [onExitClick])
+
+  // POI markers are HTML Markers (CategoryIcon roundels), not an interactive
+  // Mapbox layer, so their click is handled here rather than in handleMapClick.
+  // Like the pill/badge markers, a marker click also bubbles to the map, so set
+  // the suppress flag before opening the popup.
+  const handlePoiMarkerClick = useCallback((feature) => {
+    suppressMapClickRef.current = true
+    onPoiClick(feature)
+  }, [onPoiClick])
 
   const handleMapClick = useCallback((e) => {
     if (suppressMapClickRef.current) {
@@ -277,7 +286,7 @@ const MapView = forwardRef(function MapView({
         <POILayer
           poiData={visiblePois}
           poiPopup={poiPopup}
-          onPoiClick={onPoiClick}
+          onPoiClick={handlePoiMarkerClick}
           onPoiClose={onPoiClose}
           onTagClick={onPoiTagClick}
           onStationClick={onPopupStationClick}

--- a/src/POILayer.jsx
+++ b/src/POILayer.jsx
@@ -1,33 +1,17 @@
-import { useMemo } from 'react'
-import { Source, Layer, Popup } from 'react-map-gl'
-import { POI_CATEGORIES } from './constants'
+import { Source, Layer, Popup, Marker } from 'react-map-gl'
 import POIPopupCard from './POIPopupCard'
+import CategoryIcon from './poiIcons'
 
-const CATEGORY_KEYS = Object.keys(POI_CATEGORIES)
-
-export default function POILayer({ poiData, poiPopup, onPoiClose, onTagClick, onStationClick, onPopupFocus, darkMode, units, exitIndex }) {
-  const colorMatch = useMemo(() => [
-    'match', ['get', 'category'],
-    ...CATEGORY_KEYS.flatMap(k => [k, POI_CATEGORIES[k].color]),
-    '#999',
-  ], [])
+export default function POILayer({ poiData, poiPopup, onPoiClick, onPoiClose, onTagClick, onStationClick, onPopupFocus, darkMode, units, exitIndex }) {
   if (!poiData || !poiData.features || poiData.features.length === 0) return null
 
   return (
     <>
+      {/* Name labels stay a Mapbox symbol layer (collision-managed, zoom-gated).
+          The marker itself is now an HTML CategoryIcon roundel — the same icon
+          the popup header renders — so a place reads identically on the map and
+          in its popup (issue: POI marker migration). */}
       <Source id="pois" type="geojson" data={poiData}>
-        <Layer
-          id="poi-circles"
-          type="circle"
-          paint={{
-            'circle-radius': 6,
-            'circle-color': colorMatch,
-            'circle-stroke-width': 1.5,
-            'circle-stroke-color': darkMode ? '#1a1a2a' : '#ffffff',
-            'circle-opacity': 0.9,
-            'circle-emissive-strength': 1.0,
-          }}
-        />
         <Layer
           id="poi-labels"
           type="symbol"
@@ -36,7 +20,7 @@ export default function POILayer({ poiData, poiPopup, onPoiClose, onTagClick, on
             'text-field': ['get', 'name'],
             'text-size': 11,
             'text-font': ['DIN Pro Medium', 'Arial Unicode MS Regular'],
-            'text-offset': [0, 1.2],
+            'text-offset': [0, 1.7],
             'text-anchor': 'top',
             'text-max-width': 8,
             'text-optional': true,
@@ -49,6 +33,26 @@ export default function POILayer({ poiData, poiPopup, onPoiClose, onTagClick, on
         />
       </Source>
 
+      {poiData.features.map((f) => (
+        <Marker
+          key={f.properties.id ?? `${f.geometry.coordinates[0]},${f.geometry.coordinates[1]}`}
+          longitude={f.geometry.coordinates[0]}
+          latitude={f.geometry.coordinates[1]}
+          anchor="center"
+          onClick={(e) => {
+            // Stop the click from also reaching the map handler (which would
+            // dismiss the popup we're about to open). MapView additionally sets
+            // a suppress flag via the wrapped onPoiClick.
+            e.originalEvent?.stopPropagation()
+            onPoiClick(f)
+          }}
+        >
+          <div className="poi-marker" title={f.properties.name}>
+            <CategoryIcon category={f.properties.category} size={22} />
+          </div>
+        </Marker>
+      ))}
+
       {poiPopup && (
         <Popup
           longitude={poiPopup.longitude}
@@ -58,7 +62,7 @@ export default function POILayer({ poiData, poiPopup, onPoiClose, onTagClick, on
           closeButton={false}
           closeOnClick={false}
           className="poi-popup-container"
-          offset={12}
+          offset={20}
         >
           <POIPopupCard
             key={poiPopup.id ?? poiPopup.name}

--- a/src/__tests__/POILayer.test.jsx
+++ b/src/__tests__/POILayer.test.jsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// Mock react-map-gl primitives so POILayer can render in jsdom. Marker renders
+// its children inside a button that forwards a synthetic click, mirroring how a
+// real marker click reaches our onClick handler.
+vi.mock('react-map-gl', () => ({
+  Source: ({ children }) => <div data-testid="source">{children}</div>,
+  Layer: ({ id }) => <div data-testid={`layer-${id}`} />,
+  Marker: ({ children, onClick }) => (
+    <button
+      data-testid="marker"
+      onClick={() => onClick?.({ originalEvent: { stopPropagation: () => {} } })}
+    >
+      {children}
+    </button>
+  ),
+  Popup: ({ children }) => <div data-testid="popup">{children}</div>,
+}))
+
+import POILayer from '../POILayer'
+
+const poiData = {
+  type: 'FeatureCollection',
+  features: [
+    { type: 'Feature', properties: { id: 1, name: 'Oddfellows Cafe', category: 'cafe' }, geometry: { type: 'Point', coordinates: [-122.32, 47.61] } },
+    { type: 'Feature', properties: { id: 2, name: 'Cal Anderson Park', category: 'park' }, geometry: { type: 'Point', coordinates: [-122.31, 47.62] } },
+  ],
+}
+
+describe('POILayer markers', () => {
+  it('renders one category-roundel marker per POI with a glyph', () => {
+    render(<POILayer poiData={poiData} poiPopup={null} onPoiClick={() => {}} />)
+    expect(screen.getAllByTestId('marker')).toHaveLength(2)
+    // Each marker carries the shared CategoryIcon roundel (white glyph on color).
+    const roundels = document.querySelectorAll('.poi-marker .poi-category-icon')
+    expect(roundels).toHaveLength(2)
+    expect(document.querySelectorAll('.poi-marker .poi-category-icon svg path')).toHaveLength(2)
+  })
+
+  it('keeps the name-label symbol layer (not a circle layer)', () => {
+    render(<POILayer poiData={poiData} poiPopup={null} onPoiClick={() => {}} />)
+    expect(screen.getByTestId('layer-poi-labels')).toBeTruthy()
+    expect(screen.queryByTestId('layer-poi-circles')).toBeNull()
+  })
+
+  it('clicking a marker fires onPoiClick with that POI feature', () => {
+    const onPoiClick = vi.fn()
+    render(<POILayer poiData={poiData} poiPopup={null} onPoiClick={onPoiClick} />)
+    fireEvent.click(screen.getAllByTestId('marker')[0])
+    expect(onPoiClick).toHaveBeenCalledTimes(1)
+    expect(onPoiClick.mock.calls[0][0].properties.name).toBe('Oddfellows Cafe')
+  })
+
+  it('renders nothing when there are no POIs', () => {
+    const { container } = render(<POILayer poiData={{ type: 'FeatureCollection', features: [] }} poiPopup={null} onPoiClick={() => {}} />)
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/src/constants.js
+++ b/src/constants.js
@@ -135,4 +135,7 @@ export const DEFAULT_ENABLED_MAIN_CATEGORIES = []
 // Category tags pinned on by default when no ?pois= filter is provided.
 export const DEFAULT_ENABLED_CATEGORY_TAGS = ['coffee', 'park']
 
-export const POI_INTERACTIVE_LAYERS = ['poi-circles']
+// POI markers are HTML Markers (CategoryIcon roundels) that handle their own
+// clicks, so there are no interactive POI *layers* for map hit-testing. Kept as
+// an (empty) list so the map's interactiveLayerIds wiring stays generic.
+export const POI_INTERACTIVE_LAYERS = []

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -1127,6 +1127,20 @@ body,
   flex-shrink: 0;
 }
 
+/* POI map marker: the same category roundel as the popup header, wrapped in a
+ * white ring + soft shadow so it reads as a placed marker on the basemap. */
+.poi-marker {
+  display: inline-flex;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+  transition: transform 0.12s ease;
+}
+.poi-marker:hover {
+  transform: scale(1.12);
+}
+
 .poi-popup-title {
   flex: 1;
   min-width: 0;


### PR DESCRIPTION
`FRONTEND` — **MAP DISPATCH**

# The map marker and its popup finally agree

> _A place used to look like two different things — a flat color dot on the map, a glyphed roundel in its popup. Now both render the same `CategoryIcon`, so a café reads as a café everywhere._

> [!NOTE]
> **frontend** · feat · risk: low

Every POI carried a split identity. The map plotted it as a 6px color dot (the `poi-circles` Mapbox circle layer); the popup header showed a `CategoryIcon` roundel — a white glyph on the group color. Same place, two encodings: color-only on the map, color **and** glyph in the popup. This makes the map marker render that same `CategoryIcon`, so color + glyph encode the category in both places and there's a single icon source of truth.

## What changed
- **Marker = the popup roundel.** `POILayer` swaps the `poi-circles` circle layer for one react-map-gl `<Marker>` per POI, wrapping `<CategoryIcon size={22}>` in a white-ring + soft-shadow roundel (`.poi-marker`) — the exact component the popup header uses.
- **Names stay a symbol layer.** The `poi-labels` layer (collision-managed, zoom ≥ 15) is kept; its offset nudged to clear the larger marker.
- **Clicks still open popups.** A marker click calls `onPoiClick(feature)` with the GeoJSON feature, `stopPropagation()` + the existing `suppressMapClick` flag so it doesn't also dismiss the popup it just opened.
- **POIs leave map hit-testing.** `POI_INTERACTIVE_LAYERS` is now `[]` — markers handle their own clicks; `poi-circles` drops out of the layer-reorder list.

> _"color + glyph = group, everywhere — one `CategoryIcon`, not two representations."_

## How it flows
```mermaid
flowchart TD
  V[visiblePois GeoJSON] --> P[POILayer]
  P --> M["one Marker per POI"]
  M --> C["CategoryIcon roundel\n(glyph + group color)"]
  P --> L["poi-labels symbol layer\n(names, zoom ≥ 15)"]
  M -->|click → feature| H[handlePoiMarkerClick]
  H --> S[suppress map click]
  H --> O[open POIPopupCard]
  O --> C
```

## Verification
- `npm run lint` — clean. `npm run build` — passes.
- `npm run test -- --run` — 343 pass, incl. a new `POILayer.test.jsx`: one glyph roundel per POI, label layer kept (not a circle layer), marker click fires `onPoiClick`, empty render with no POIs. The 8 `hintsState.test.js` failures are a pre-existing node/jsdom `localStorage` env issue (identical on the clean tree).
- `npm run e2e` — smoke green (9/9): app boots, map canvas + legend render with the marker change.
- Visual screenshot blocked in headless only by the Mapbox **Isochrone 403** (the `pk.` build token is referrer-restricted to `walksheds.xyz`, so the walkshed — and thus POIs — won't load on `localhost`); markers render in production where the token is unrestricted. The new unit test covers the render/click path deterministically instead.

## Risk & rollout
- **Low** — no palette or glyph change, so no accessibility or brand regression. Behavioral surface is the POI marker + its click; stations, walksheds, search untouched.
- **Rollback** = restore the `poi-circles` layer in `POILayer` and `POI_INTERACTIVE_LAYERS = ['poi-circles']`.
- **Follow-up (declutter):** roundels are larger than dots (≈26px vs 14px), so dense clusters collide more at low zoom. POIs are already walkshed-scoped (bounded counts), but a zoom-threshold swap (dots far out → roundels zoomed in) or Mapbox collision handling is the natural next step if density bites.
