### PR TITLE
fix: POI popup distance no longer crowds the station roundel + EXIT badge

### DIFF
--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -1363,7 +1363,10 @@ body,
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  /* Row-gap kicks in only when the distance wraps to its own line (see
+     .poi-popup-station-dist) — keeps the wrapped distance clear of the pill. */
+  gap: 2px 10px;
+  flex-wrap: wrap;
   padding: 3px 4px;
   border: none;
   background: transparent;
@@ -1392,6 +1395,9 @@ body,
   border-radius: 999px;
   font-size: 11px;
   pointer-events: none;
+  /* The roundel keeps its priority: it never compresses to make room for the
+     distance text — only the (optional) station name truncates. */
+  flex-shrink: 0;
 }
 
 .app.dark .poi-popup-station-row .station-pill.inline {
@@ -1413,12 +1419,17 @@ body,
   font-size: 10px;
 }
 
-/* Left group of a station row: the station pill + its best-exit badge. */
+/* Left group of a station row: the station pill + its best-exit badge. It
+   keeps priority over the distance — the roundel and EXIT badge never shrink
+   (only an optional station name truncates inside the pill); when even the
+   minimal group plus the distance can't fit, the distance wraps below instead
+   of crowding the badge. */
 .poi-popup-station-left {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
+  flex: 1 1 auto;
 }
 
 /* Inline best-exit badge — the same green EXIT-sign idiom as the map markers,
@@ -1446,6 +1457,9 @@ body,
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   flex-shrink: 0;
+  /* Sit flush right; if the row runs out of width the whole distance wraps to
+     its own line (under the pill) rather than squeezing the roundel/EXIT badge. */
+  margin-left: auto;
 }
 
 .app.dark .poi-popup-station-dist {


### PR DESCRIPTION
`UI` — **CARTOGRAPHY DESK**

# The distance text stops elbowing the station roundel

> _In a POI popup's nearest-stations list, a long walking distance used to crowd the green EXIT badge to a hair's-breadth gap. Now the roundel and badge always win the row._

> [!NOTE]
> **popup UI** · fix · risk: low

Each row in a popup's "Stations within a 15 min walk" list is a flex line: roundel + green EXIT badge on the left, walking distance on the right.

It was `space-between` with both sides effectively non-shrinking and nowrap. In a fixed ~240px popup, a long distance ("1.1 km · 13 min", or imperial "0.7 mi · 13 min") had nothing to give — so it crept up to the EXIT badge (a fragile ~8px gap) and could clip the roundel when the station name showed.

## The fix: the left group owns the row

- `.poi-popup-station-left` → `flex: 1 1 auto` + `min-width: 0`: absorbs spare width, yields it back when tight.
- Inline station pill → `flex-shrink: 0`: the **roundel never compresses**; only an optional name truncates inside it.
- `.poi-popup-station-dist` → `margin-left: auto` (still `flex-shrink: 0` + nowrap): sits flush right with a guaranteed gap, stays whole.
- Row → `flex-wrap: wrap` (2px/10px gap): in the worst case the distance drops to its **own line under the pill** instead of overlapping the badge.

> _"Roundel and EXIT badge keep priority; the distance is inline when it fits, on its own line when it doesn't."_

## How it flows

No control/data flow changed — this is a pure CSS layout fix.

## Screens

Before (metric) — distance crowding the EXIT badge:

<img width="300" alt="Before: walking distance sits tight against the green EXIT badge" src="https://raw.githubusercontent.com/tommyroar/walksheds/refs/heads/pr-assets/fix-exit-spacing/before-metric.png">

After (worst case) — long station name visible + "1.1 km · 13 min": the distance wraps onto its own line, roundel + EXIT badge intact:

<img width="300" alt="After: distance wraps onto its own line under the station pill, roundel and EXIT badge intact" src="https://raw.githubusercontent.com/tommyroar/walksheds/refs/heads/pr-assets/fix-exit-spacing/after-worstcase-wrap.png">

## Verification

- Playwright on `localhost/seattle/1/53` (Royal Brougham Park popup: Intl District + Stadium rows).
- Bounding-box checks in **metric and imperial**: left group and distance never overlap; distance flush right with a clean gap.
- Longest realistic strings + visible long name: distance wraps to its own line; roundel + EXIT badge never squeezed or clipped.
- `npm run lint` clean; `POIPopupCard.test.jsx` 12/12 pass. (8 pre-existing `hintsState.test.js` failures exist on clean `main` — unrelated.)

## Risk & rollout

- CSS-only (`src/walksheds.css`); no JS, markup, or data. No emoji (INV-018).
- `.pr-assets/` holds the before/after PNGs for this newspaper — branch-only, not imported by source; drop before merge.

