### PR TITLE
Add POI feedback control that queues reports as GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/poi-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/poi-feedback.yml
@@ -1,0 +1,47 @@
+name: POI feedback
+description: Flag a map listing that is closed, a duplicate, or inaccurate.
+title: "POI feedback: "
+labels: ["poi-feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping keep the map accurate. Most reports are filed
+        automatically from the popup's "Report a problem" control with these
+        fields prefilled — but you can also file one by hand here. Please keep
+        the field values so the report can be batch-processed.
+  - type: dropdown
+    id: reason
+    attributes:
+      label: Reason
+      description: What's wrong with this listing?
+      options:
+        - closed
+        - duplicate
+        - inaccurate
+    validations:
+      required: true
+  - type: input
+    id: poi_id
+    attributes:
+      label: POI ID
+      description: The listing's id (OSM node/way id, or Overture GERS id). Leave blank if unknown.
+      placeholder: e.g. 201028146
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      description: The listing's name as shown on the map.
+    validations:
+      required: true
+  - type: input
+    id: coordinates
+    attributes:
+      label: Coordinates
+      description: "Latitude, longitude (helps locate the listing if the id is missing)."
+      placeholder: "47.6062, -122.3321"
+  - type: textarea
+    id: details
+    attributes:
+      label: Additional details
+      description: Anything else that helps fix it (e.g. which listing it duplicates, the correct hours).

--- a/docs/poi-feedback.md
+++ b/docs/poi-feedback.md
@@ -1,0 +1,56 @@
+# POI feedback queue
+
+The POI popup carries a **Report a problem** control (`src/POIPopupCard.jsx`,
+`src/poiFeedback.js`). Because the site is a static GitHub Pages SPA with no
+backend, a report can't be POSTed anywhere — instead the button opens a
+**prefilled GitHub issue** in a new tab, labeled `poi-feedback`, with the
+listing's identity baked into the body. The label is the queue: reports
+accumulate as open issues for an agent to batch-process.
+
+Manually filed reports use the same shape via the issue form at
+`.github/ISSUE_TEMPLATE/poi-feedback.yml`.
+
+## Issue body shape
+
+App-filed issues contain a stable `key: value` block (parse this, don't scrape prose):
+
+```
+Reason: closed | duplicate | inaccurate
+POI ID: <osm id or overture gers id>
+Name: <listing name>
+Category: <category>
+Sources: osm, overture          # which upstream(s) the listing came from
+Coordinates: <lat>, <lng>
+Nearest station: <name> (stopCode <n>, lines <1|2|1,2>)
+```
+
+## Batch triage (for an agent)
+
+1. **Collect** — list open issues labeled `poi-feedback`
+   (`mcp__github__list_issues` with `labels: ["poi-feedback"]`, or `search_issues`).
+2. **Parse** — extract the `key: value` block from each body; group by `Reason`.
+3. **Apply fixes:**
+   - **closed / duplicate, OSM-sourced** (`Sources` includes `osm`, numeric POI ID):
+     add the OSM id to `DENY_OSM_IDS` in `data/pois/fetch_pois.py`. This is honored
+     by the production tile build too — `build_refined.py` imports `build_category`,
+     which calls `is_closed_or_denied` (see `data/pois/fetch_pois.py:700`). For a
+     **duplicate**, deny the lower-quality of the pair (keep the one with richer
+     contact/tag data).
+   - **Overture-only POIs** (string/GERS id, `Sources` is `overture` only): **not
+     covered by `DENY_OSM_IDS`.** There is no Overture exclusion mechanism yet —
+     flag these for the maintainer rather than guessing. (A future `DENY_GERS_IDS`
+     set filtered inside `build_refined.py` would close this gap.)
+   - **inaccurate**: prefer fixing upstream in OpenStreetMap so the next `--refresh`
+     picks it up; otherwise note for a future field-override mechanism.
+4. **Rebuild + ship** — `python3 data/pois/build_refined.py` regenerates the tiles
+   (needs network for the Overture S3 query). Commit the changed tiles +
+   `data/pois/fetch_pois.py`, push; `deploy.yml` publishes to GitHub Pages. The
+   data-invariants CI job re-verifies INV-019 (tile coverage) and INV-020
+   (station→tile lookup) after the rebuild.
+5. **Close** — close each processed issue, referencing the commit that fixed it.
+
+## One-time setup
+
+The `poi-feedback` label must exist in the repo for the `?labels=poi-feedback`
+query param (and the issue form's `labels:`) to stick. Create it once via the
+GitHub UI or API.

--- a/src/POIPopupCard.jsx
+++ b/src/POIPopupCard.jsx
@@ -3,6 +3,7 @@ import { POI_CATEGORIES } from './constants'
 import { StationPillBody } from './StationPill'
 import { formatWalk } from './formatDistance'
 import { nearestExit, exitCode } from './stationExits'
+import { buildFeedbackIssueUrl, REPORT_REASONS } from './poiFeedback'
 import CategoryIcon from './poiIcons'
 
 // Expandable POI card (issue #19), styled to match the legend: a category
@@ -72,6 +73,16 @@ function buildInfoRows(poi) {
   return rows
 }
 
+// Small flag glyph for the "Report a problem" control — drawn in the same
+// inline-SVG idiom as INFO_ICONS so it reads as house iconography, not an emoji.
+function FlagIcon() {
+  return (
+    <svg className="poi-popup-report-icon" width="11" height="11" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M6 21V4 M6 4h11l-2 3.5L17 11H6" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+    </svg>
+  )
+}
+
 // The green "EXIT" badge for the station's best exit to this POI, rendered
 // inline with the roundel so the card tells the rider which door to leave by.
 function ExitBadge({ exit }) {
@@ -86,6 +97,7 @@ function ExitBadge({ exit }) {
 export default function POIPopupCard({ poi, onClose, onTagClick, onStationClick, onPopupFocus, units, exitIndex }) {
   const [tagsExpanded, setTagsExpanded] = useState(false)
   const [infoExpanded, setInfoExpanded] = useState(false)
+  const [reportOpen, setReportOpen] = useState(false)
 
   // The POI's own coordinates, used to pick each station's closest exit.
   const poiCoord = poi.longitude != null && poi.latitude != null
@@ -101,6 +113,13 @@ export default function POIPopupCard({ poi, onClose, onTagClick, onStationClick,
   const hiddenRowCount = infoRows.length - COLLAPSED_INFO_ROWS
 
   const categoryLabel = POI_CATEGORIES[poi.category]?.label
+
+  // Open a prefilled GitHub issue for the chosen flag reason, then collapse the
+  // picker. The new tab carries the listing's identity for later batch triage.
+  const handleReport = reasonKey => {
+    window.open(buildFeedbackIssueUrl(poi, reasonKey), '_blank', 'noopener,noreferrer')
+    setReportOpen(false)
+  }
 
   return (
     <div className="poi-popup" onMouseDown={onPopupFocus}>
@@ -185,6 +204,30 @@ export default function POIPopupCard({ poi, onClose, onTagClick, onStationClick,
           })}
         </div>
       )}
+
+      <div className="poi-popup-report">
+        <button
+          className="poi-popup-report-trigger"
+          onClick={() => setReportOpen(v => !v)}
+          aria-expanded={reportOpen}
+        >
+          <FlagIcon />
+          Report a problem
+        </button>
+        {reportOpen && (
+          <div className="poi-popup-report-reasons" role="group" aria-label="Report a problem">
+            {REPORT_REASONS.map(r => (
+              <button
+                key={r.key}
+                className="poi-popup-report-reason"
+                onClick={() => handleReport(r.key)}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/__tests__/POIPopupCard.test.jsx
+++ b/src/__tests__/POIPopupCard.test.jsx
@@ -133,3 +133,33 @@ describe('POIPopupCard stations section', () => {
     expect(document.querySelector('.poi-popup-exit-badge')).toBeNull()
   })
 })
+
+describe('POIPopupCard report control', () => {
+  it('reveals the three flag reasons only after the trigger is clicked', () => {
+    renderCard()
+    expect(screen.queryByText('Closed')).toBeNull()
+    fireEvent.click(screen.getByText('Report a problem'))
+    expect(screen.getByText('Closed')).toBeTruthy()
+    expect(screen.getByText('Duplicate')).toBeTruthy()
+    expect(screen.getByText('Inaccurate')).toBeTruthy()
+  })
+
+  it('opens a prefilled GitHub issue for the chosen reason and collapses the picker', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    renderCard()
+    fireEvent.click(screen.getByText('Report a problem'))
+    fireEvent.click(screen.getByText('Duplicate'))
+
+    expect(open).toHaveBeenCalledTimes(1)
+    const url = open.mock.calls[0][0]
+    expect(url).toContain('github.com/tommyroar/walksheds/issues/new')
+    expect(url).toContain('labels=poi-feedback')
+    const body = new URL(url).searchParams.get('body')
+    expect(body).toContain('Reason: duplicate')
+    expect(body).toContain('POI ID: 42')
+    // Picker collapses again after a reason is chosen.
+    expect(screen.queryByText('Duplicate')).toBeNull()
+
+    open.mockRestore()
+  })
+})

--- a/src/__tests__/poiFeedback.test.js
+++ b/src/__tests__/poiFeedback.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { buildFeedbackIssueUrl, REPORT_REASONS } from '../poiFeedback'
+
+const POI = {
+  id: 201028146,
+  name: "Dick's Drive-In",
+  category: 'fast_food',
+  sources: ['osm', 'overture'],
+  latitude: 47.6191,
+  longitude: -122.3211,
+  stations: [
+    { stopCode: 49, lines: '1,2', name: 'Capitol Hill Station', walkingMeters: 350, walkingSeconds: 280, band: 5 },
+  ],
+}
+
+// Decode the prefilled body back out of the issue URL for assertions.
+function bodyOf(url) {
+  return new URL(url).searchParams.get('body')
+}
+
+describe('buildFeedbackIssueUrl', () => {
+  it('targets the walksheds repo new-issue endpoint with the poi-feedback label', () => {
+    const url = new URL(buildFeedbackIssueUrl(POI, 'closed'))
+    expect(url.origin + url.pathname).toBe('https://github.com/tommyroar/walksheds/issues/new')
+    expect(url.searchParams.get('labels')).toBe('poi-feedback')
+  })
+
+  it('puts the reason and name in the title', () => {
+    const title = new URL(buildFeedbackIssueUrl(POI, 'duplicate')).searchParams.get('title')
+    expect(title).toBe("POI feedback: duplicate — Dick's Drive-In")
+  })
+
+  it('embeds the parseable identity block in the body', () => {
+    const body = bodyOf(buildFeedbackIssueUrl(POI, 'inaccurate'))
+    expect(body).toContain('Reason: inaccurate')
+    expect(body).toContain('POI ID: 201028146')
+    expect(body).toContain("Name: Dick's Drive-In")
+    expect(body).toContain('Category: fast_food')
+    expect(body).toContain('Sources: osm, overture')
+    expect(body).toContain('Coordinates: 47.6191, -122.3211')
+    expect(body).toContain('Nearest station: Capitol Hill Station (stopCode 49, lines 1,2)')
+  })
+
+  it('URL-encodes special characters in the body', () => {
+    const raw = buildFeedbackIssueUrl(POI, 'closed')
+    // The apostrophe and spaces must be percent-encoded, not left literal.
+    expect(raw).not.toContain("Dick's Drive-In")
+    expect(bodyOf(raw)).toContain("Dick's Drive-In")
+  })
+
+  it('omits absent fields and tolerates a missing id', () => {
+    const body = bodyOf(buildFeedbackIssueUrl({ name: 'Mystery Spot' }, 'closed'))
+    expect(body).toContain('POI ID: (unknown)')
+    expect(body).not.toContain('Category:')
+    expect(body).not.toContain('Coordinates:')
+    expect(body).not.toContain('Nearest station:')
+  })
+
+  it('exposes the three flag reasons', () => {
+    expect(REPORT_REASONS.map(r => r.key)).toEqual(['closed', 'duplicate', 'inaccurate'])
+  })
+})

--- a/src/poiFeedback.js
+++ b/src/poiFeedback.js
@@ -1,0 +1,55 @@
+// POI feedback queue (issue #N): the app is a static GitHub Pages SPA with no
+// backend, so a report can't be POSTed anywhere from the browser. Instead the
+// popup's "Report a problem" control opens a prefilled GitHub issue in a new
+// tab, labeled `poi-feedback`, with the listing's identity baked into the body.
+// An agent later lists issues with that label and batch-applies fixes (extend
+// DENY_OSM_IDS, rebuild tiles, close the issue). See docs/poi-feedback.md.
+
+// Matches public/CNAME / CLAUDE.md. Kept here so the URL builder is self-contained.
+const REPO = 'tommyroar/walksheds'
+const FEEDBACK_LABEL = 'poi-feedback'
+
+// The three flag reasons surfaced as chips in the popup.
+export const REPORT_REASONS = [
+  { key: 'closed', label: 'Closed' },
+  { key: 'duplicate', label: 'Duplicate' },
+  { key: 'inaccurate', label: 'Inaccurate' },
+]
+
+// A stable, machine-parseable `key: value` block so the triage agent can pull a
+// listing's identity out of the issue body without scraping prose. Lines are
+// only emitted when the underlying field is present.
+function buildBody(poi, reason) {
+  const lines = [
+    'Reported from the Walksheds map. Please leave the block below intact so it can be batch-processed.',
+    '',
+    `Reason: ${reason}`,
+    `POI ID: ${poi.id ?? '(unknown)'}`,
+    `Name: ${poi.name ?? '(unknown)'}`,
+  ]
+  if (poi.category) lines.push(`Category: ${poi.category}`)
+  if (Array.isArray(poi.sources) && poi.sources.length) {
+    lines.push(`Sources: ${poi.sources.join(', ')}`)
+  }
+  if (poi.latitude != null && poi.longitude != null) {
+    lines.push(`Coordinates: ${poi.latitude}, ${poi.longitude}`)
+  }
+  const nearest = Array.isArray(poi.stations) ? poi.stations[0] : null
+  if (nearest) {
+    lines.push(`Nearest station: ${nearest.name} (stopCode ${nearest.stopCode}, lines ${nearest.lines})`)
+  }
+  lines.push('', 'Additional details:', '')
+  return lines.join('\n')
+}
+
+// Build the prefilled GitHub "new issue" URL for a POI report. `reason` is a
+// REPORT_REASONS key (closed / duplicate / inaccurate).
+export function buildFeedbackIssueUrl(poi, reason) {
+  const title = `POI feedback: ${reason} — ${poi.name ?? 'unknown listing'}`
+  const params = new URLSearchParams({
+    title,
+    body: buildBody(poi, reason),
+    labels: FEEDBACK_LABEL,
+  })
+  return `https://github.com/${REPO}/issues/new?${params.toString()}`
+}

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -1331,6 +1331,87 @@ body,
   color: rgba(255, 255, 255, 0.7);
 }
 
+/* ── "Report a problem" control in POI popup ── */
+
+.poi-popup-report {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.app.dark .poi-popup-report {
+  border-top-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Secondary action — muted like the expander, never a primary CTA. */
+.poi-popup-report-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  background: transparent;
+  padding: 2px 6px;
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.45);
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.poi-popup-report-trigger:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.app.dark .poi-popup-report-trigger {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.app.dark .poi-popup-report-trigger:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.poi-popup-report-reasons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding-left: 2px;
+}
+
+.poi-popup-report-reason {
+  border: none;
+  background: rgba(0, 0, 0, 0.06);
+  padding: 3px 8px;
+  font-family: inherit;
+  font-size: 11px;
+  color: #555;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.poi-popup-report-reason:hover {
+  background: rgba(0, 0, 0, 0.12);
+  color: #222;
+}
+
+.app.dark .poi-popup-report-reason {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app.dark .poi-popup-report-reason:hover {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+
 /* ── Nearest-stations section in POI popup ── */
 
 .poi-popup-stations {


### PR DESCRIPTION
*Data quality · POI popup*

# One-tap "Report a problem" on POI popups, queued as labeled GitHub issues

> **TL;DR** A new popup control flags a listing as closed, duplicate, or inaccurate; with no backend it opens a prefilled, `poi-feedback`-labeled GitHub issue, so reports collect into a queue an agent batch-processes later.

> [!NOTE]
> **Area** POI popup + data pipeline · **Type** feature · **Risk** low (additive, nothing removed) · **Closes** n/a

## Why & what

POI tiles (OSM + Overture) inevitably carry closed/duplicate/wrong listings, and the only fix path was hand-editing `DENY_OSM_IDS`. This gives viewers a way to report, without a server.

- `src/poiFeedback.js` — `buildFeedbackIssueUrl()` (title + `poi-feedback` label + parseable `key: value` body) and `REPORT_REASONS`.
- `src/POIPopupCard.jsx` + `walksheds.css` — footer control, inline-SVG flag, no emoji (INV-018); reveals Closed / Duplicate / Inaccurate, opens the issue in a new tab.
- `.github/ISSUE_TEMPLATE/poi-feedback.yml` — matching form · `docs/poi-feedback.md` — triage workflow · tests for both pieces.

## Flow

```mermaid
flowchart TD
  A[Tap Report a problem] --> B[Pick reason]
  B --> C[Prefilled issue<br/>label: poi-feedback]
  C --> D[Agent batch triage]
  D --> E[DENY_OSM_IDS + rebuild + close]
```

## Screen

![Report reasons expanded on the POI popup](https://raw.githubusercontent.com/tommyroar/walksheds/assets/pr73-screenshots/pr73/02-light-expanded.png)

## Verify & risk

`npm run test -- --run` (365 pass, +7 new) and `npm run lint` clean; screenshots rendered from the real component in headless Chromium (collapsed + expanded, light/dark on the PR thread). Additive only. Two noted follow-ups in `docs/poi-feedback.md`: create the `poi-feedback` label once, and Overture-only POIs aren't yet covered by the OSM deny list.