### PR TITLE
Fix POI feedback link on iOS: use an anchor, not window.open

### DIFF
--- a/src/POIPopupCard.jsx
+++ b/src/POIPopupCard.jsx
@@ -114,13 +114,6 @@ export default function POIPopupCard({ poi, onClose, onTagClick, onStationClick,
 
   const categoryLabel = POI_CATEGORIES[poi.category]?.label
 
-  // Open a prefilled GitHub issue for the chosen flag reason, then collapse the
-  // picker. The new tab carries the listing's identity for later batch triage.
-  const handleReport = reasonKey => {
-    window.open(buildFeedbackIssueUrl(poi, reasonKey), '_blank', 'noopener,noreferrer')
-    setReportOpen(false)
-  }
-
   return (
     <div className="poi-popup" onMouseDown={onPopupFocus}>
       <div className="poi-popup-header">
@@ -217,13 +210,21 @@ export default function POIPopupCard({ poi, onClose, onTagClick, onStationClick,
         {reportOpen && (
           <div className="poi-popup-report-reasons" role="group" aria-label="Report a problem">
             {REPORT_REASONS.map(r => (
-              <button
+              // A real anchor (not window.open): inside an iOS home-screen PWA
+              // or in-app browser, a JS popup gets dropped and the current view
+              // navigates away — landing on the repo root and breaking the app
+              // on "back". An anchor opens in the system browser and leaves the
+              // map view intact. (issue: iOS feedback link)
+              <a
                 key={r.key}
                 className="poi-popup-report-reason"
-                onClick={() => handleReport(r.key)}
+                href={buildFeedbackIssueUrl(poi, r.key)}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setReportOpen(false)}
               >
                 {r.label}
-              </button>
+              </a>
             ))}
           </div>
         )}

--- a/src/__tests__/POIPopupCard.test.jsx
+++ b/src/__tests__/POIPopupCard.test.jsx
@@ -144,22 +144,27 @@ describe('POIPopupCard report control', () => {
     expect(screen.getByText('Inaccurate')).toBeTruthy()
   })
 
-  it('opens a prefilled GitHub issue for the chosen reason and collapses the picker', () => {
-    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+  it('links each reason to a prefilled GitHub issue via a real anchor', () => {
+    // A plain anchor (not window.open) so iOS opens it in the system browser
+    // instead of breaking the home-screen PWA / in-app webview.
+    renderCard()
+    fireEvent.click(screen.getByText('Report a problem'))
+    const anchor = screen.getByText('Duplicate').closest('a')
+    expect(anchor).toBeTruthy()
+    expect(anchor.getAttribute('target')).toBe('_blank')
+    expect(anchor.getAttribute('rel')).toContain('noopener')
+    const url = new URL(anchor.getAttribute('href'))
+    expect(url.origin + url.pathname).toBe('https://github.com/tommyroar/walksheds/issues/new')
+    expect(url.searchParams.get('labels')).toBe('poi-feedback')
+    const body = url.searchParams.get('body')
+    expect(body).toContain('Reason: duplicate')
+    expect(body).toContain('POI ID: 42')
+  })
+
+  it('collapses the picker after a reason is chosen', () => {
     renderCard()
     fireEvent.click(screen.getByText('Report a problem'))
     fireEvent.click(screen.getByText('Duplicate'))
-
-    expect(open).toHaveBeenCalledTimes(1)
-    const url = open.mock.calls[0][0]
-    expect(url).toContain('github.com/tommyroar/walksheds/issues/new')
-    expect(url).toContain('labels=poi-feedback')
-    const body = new URL(url).searchParams.get('body')
-    expect(body).toContain('Reason: duplicate')
-    expect(body).toContain('POI ID: 42')
-    // Picker collapses again after a reason is chosen.
     expect(screen.queryByText('Duplicate')).toBeNull()
-
-    open.mockRestore()
   })
 })

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -1386,12 +1386,15 @@ body,
 }
 
 .poi-popup-report-reason {
+  display: inline-flex;
+  align-items: center;
   border: none;
   background: rgba(0, 0, 0, 0.06);
   padding: 3px 8px;
   font-family: inherit;
   font-size: 11px;
   color: #555;
+  text-decoration: none;
   cursor: pointer;
   border-radius: 6px;
   transition: background 0.15s ease, color 0.15s ease;


### PR DESCRIPTION
*Bug fix · POI popup*

# Report-a-problem links now open correctly on iOS instead of dumping you at the repo root

> **TL;DR** The feedback reason chips used `window.open`, which an iOS home-screen PWA / in-app webview drops — navigating the current view to GitHub's repo root and breaking the app on "back". They're now real anchors that open in the system browser and leave the map intact.

> [!NOTE]
> **Area** POI popup · **Type** bug fix · **Risk** low (one interaction primitive swapped) · **Closes** n/a

## Why & what

On iOS, tapping a reason (Closed / Duplicate / Inaccurate) sent you to the repo root, and returning to the app left it broken. Cause: `window.open(url, '_blank', …)` from a click handler is dropped inside a standalone PWA / in-app webview, so the current view navigates away.

- `src/POIPopupCard.jsx` — each reason is now `<a href={buildFeedbackIssueUrl(...)} target="_blank" rel="noopener noreferrer">`; removed the `window.open` handler.
- `src/walksheds.css` — anchor resets on `.poi-popup-report-reason` (`text-decoration:none`, `inline-flex`) so the chip looks identical.
- `src/__tests__/POIPopupCard.test.jsx` — assert the anchor `href`/`target`/`rel` instead of mocking `window.open`.

No visual change — behavioral fix only.

## Flow

```mermaid
flowchart TD
  A[Tap reason chip] --> B[Anchor opens in system browser]
  B --> C[Prefilled GitHub issue]
  C -.back.-> D[Walksheds map still intact]
```

## Verify & risk

`npm run test -- --run` (366 pass) and `npm run lint` clean. Low risk, additive. Caveat: if the GitHub iOS app claims the github.com universal link on a genuine tap, it may still open the app at repo root — the GitHub mobile app doesn't support the prefilled new-issue compose deep link. The anchor fixes the standalone-PWA / in-app-webview cases (the reported symptoms); a "copy report details" fallback is a possible later mitigation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8dHKJ6UjkDSdHpzvqrhkq)_