### PR TITLE
infra: make dev.wiki DNS-only so its cert provisions

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -45,14 +45,21 @@ resource "cloudflare_dns_record" "wiki" {
 }
 
 # dev.wiki.walksheds.xyz — the engineering codex, on its own GitHub Pages site
-# (tommyroar/walksheds-dev-wiki). A second-level subdomain; GitHub Pages binds it
-# via the repo's CNAME just like a single-level one.
+# (tommyroar/walksheds-dev-wiki).
+#
+# DNS-only (grey cloud), unlike the proxied apex/www/wiki records. This is a
+# SECOND-level subdomain, and Cloudflare's Universal SSL wildcard (`*.walksheds.xyz`)
+# does NOT cover a second level — a proxied `dev.wiki` has no edge cert and fails the
+# TLS handshake (would need Advanced Certificate Manager / Total TLS). DNS-only takes
+# Cloudflare out of the TLS path so GitHub Pages serves its own per-hostname Let's
+# Encrypt cert, which covers any subdomain depth. (`wiki`, being first-level, is
+# covered by Universal SSL and stays proxied.)
 resource "cloudflare_dns_record" "dev_wiki" {
   zone_id = data.cloudflare_zone.main.id
   name    = "dev.wiki"
   content = "${var.github_pages_user}.github.io"
   type    = "CNAME"
-  proxied = true
+  proxied = false
   ttl     = 1
 }
 


### PR DESCRIPTION
*Fix · infra/DNS*

# Make dev.wiki.walksheds.xyz DNS-only so GitHub Pages can serve its cert

> **TL;DR** `dev.wiki` is a second-level subdomain. Cloudflare Universal SSL (`*.walksheds.xyz`) doesn't cover a second level, so the proxied record had no edge cert and failed the TLS handshake. Flipping it to DNS-only lets GitHub Pages serve its own per-hostname Let's Encrypt cert. `wiki` (first-level) is covered by Universal SSL and stays proxied.

> [!NOTE]
> **Area** infra/DNS · **Type** fix · **Risk** low (one record's proxy flag) · **Follows** #75

## Why & what

After the two Pages sites went live, `wiki.walksheds.xyz` served HTTPS 200 (first-level, proxied, covered by Universal SSL) but `dev.wiki.walksheds.xyz` returned an `sslv3 alert handshake failure` — Cloudflare's edge has no certificate for a second-level name under the `*.walksheds.xyz` wildcard.

- `infra/main.tf` — `cloudflare_dns_record.dev_wiki` set `proxied = false` (DNS-only / grey cloud), with a comment explaining the Universal SSL second-level gap. Cloudflare leaves the TLS path, GitHub Pages provisions and serves the cert directly (it covers any subdomain depth).

The alternative (keep it proxied) would need Cloudflare Advanced Certificate Manager / Total TLS for second-level coverage — paid and heavier than this docs subdomain warrants.

## Verify & risk

`tofu apply` flipped the one record in place (`proxied: true -> false`). `wiki.walksheds.xyz` is unaffected and already serving. Low risk — DNS-only just removes the Cloudflare proxy for this one hostname; the origin is a public GitHub Pages site.

---
_Generated with [Claude Code](https://claude.com/claude-code)_
