### PR TITLE
Embeddable Walksheds: iframe embed mode + postMessage bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,10 @@ To preview a branch on the live Pages URL (overrides main until the next main pu
 
 The next push to `main` will re-deploy main's build via `deploy.yml` and overwrite the preview.
 
+## Embedding
+
+The app is embeddable in other sites/dashboards as an iframe served from `walksheds.xyz` (iframe — not a JS bundle — because the Mapbox token is origin-restricted and framing isolates CSS/global state). `?embed=1` parses a frozen config (`src/embedConfig.js`) that strips onboarding/branding chrome, stops writing to the URL + `localStorage` (the frame shares the real site's origin storage), and opens a two-way `postMessage` bridge (`src/embedBridge.js`, `useEmbedBridge`). Chrome is gated by JSX (legend/search), `LineLegend` `show*` props (help/guide/dark toggles), and `.app` CSS modifier classes (`embed-hide-report`, `embed-hide-locate`). Host helper + live demo: `public/embed.js`, `public/embed.html`. Full reference: `wiki/codex/docs/embedding.md`.
+
 ## Testing
 
 - **JS unit tests**: Vitest + jsdom + React Testing Library (`src/__tests__/`)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Two companion sites, both published to the `walksheds-wiki` GitHub Pages repo (s
 
 `CLAUDE.md` remains the canonical short-form reference for the house rules and the full `INV-NNN` invariant list.
 
+## Embedding
+
+Walksheds can be dropped into any page or dashboard as an iframe with `?embed=1`, a URL-param config API, and a two-way `postMessage` bridge. See the live demo + snippet generator at <https://walksheds.xyz/embed.html>, the helper at `public/embed.js`, and the full reference in the [codex embedding guide](https://wiki.walksheds.xyz/dev/embedding/).
+
 ## POI selection logic
 
 Three independent inputs decide which POIs are visible inside a walkshed:

--- a/public/embed.html
+++ b/public/embed.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Embed Walksheds — Seattle Link Light Rail walkshed explorer</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <style>
+    :root {
+      --line1: #38B030;
+      --line2: #00A0E0;
+      --ink: #1a1a1a;
+      --muted: #666;
+      --line: #e2e2e2;
+      --bg: #f4f0ef;
+      --card: #ffffff;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+      line-height: 1.5;
+    }
+    header {
+      border-bottom: 4px solid var(--line2);
+      background: var(--card);
+      padding: 22px 24px;
+    }
+    header h1 { margin: 0 0 4px; font-size: 24px; letter-spacing: -0.01em; }
+    header p { margin: 0; color: var(--muted); font-size: 15px; }
+    .wrap { max-width: 1040px; margin: 0 auto; padding: 24px; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+    @media (max-width: 860px) { .grid { grid-template-columns: 1fr; } }
+    h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); margin: 28px 0 12px; }
+    .card { background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 16px; }
+    .controls { display: flex; flex-direction: column; gap: 14px; }
+    .row { display: flex; flex-wrap: wrap; gap: 10px 16px; align-items: center; }
+    label.field { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--muted); }
+    label.chk { display: inline-flex; align-items: center; gap: 6px; font-size: 14px; color: var(--ink); }
+    select, input[type="text"] {
+      font: inherit; padding: 6px 8px; border: 1px solid var(--line); border-radius: 8px; background: #fff;
+    }
+    #preview { width: 100%; }
+    pre {
+      background: #0f1220; color: #e6e8f0; border-radius: 12px; padding: 16px; overflow-x: auto;
+      font-size: 13px; line-height: 1.5; margin: 0;
+    }
+    .copy { margin-top: 8px; font: inherit; padding: 7px 12px; border: 1px solid var(--line); border-radius: 8px; background: #fff; cursor: pointer; }
+    .copy:hover { background: #f2f2f2; }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    th, td { text-align: left; padding: 7px 10px; border-bottom: 1px solid var(--line); vertical-align: top; }
+    th { color: var(--muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+    code { background: #eef0f4; padding: 1px 5px; border-radius: 4px; font-size: 0.92em; }
+    .table-scroll { overflow-x: auto; }
+    .pill { display: inline-flex; align-items: center; gap: 3px; background: #fff; border: 1.5px solid #333; border-radius: 12px; padding: 2px 6px 2px 3px; font-size: 12px; font-weight: 600; }
+    .pill .c { width: 15px; height: 15px; border-radius: 50%; color: #fff; display: inline-flex; align-items: center; justify-content: center; font-size: 9px; }
+    .status { font-size: 13px; color: var(--muted); min-height: 18px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Embed Walksheds</h1>
+    <p>Drop the Seattle Link Light Rail walkshed explorer into any page or dashboard.</p>
+  </header>
+
+  <div class="wrap">
+    <div class="grid">
+      <div>
+        <h2>Live preview</h2>
+        <div id="preview"></div>
+        <p class="status" id="status">Loading…</p>
+      </div>
+      <div>
+        <h2>Configure</h2>
+        <div class="card controls">
+          <label class="field">Station
+            <select id="station">
+              <option value="seattle/1/50">Westlake (1,2 · 50)</option>
+              <option value="seattle/1/49">Capitol Hill (1,2 · 49)</option>
+              <option value="seattle/1/58">Columbia City (1 · 58)</option>
+              <option value="seattle/2/58">Bellevue Downtown (2 · 58)</option>
+              <option value="seattle/1/64">SeaTac/Airport (1 · 64)</option>
+            </select>
+          </label>
+          <div class="row" id="bands">
+            <strong style="font-size:13px">Walksheds:</strong>
+            <label class="chk"><input type="checkbox" value="5" checked> 5 min</label>
+            <label class="chk"><input type="checkbox" value="10" checked> 10 min</label>
+            <label class="chk"><input type="checkbox" value="15" checked> 15 min</label>
+          </div>
+          <label class="field">POI filters (comma-separated tags)
+            <input type="text" id="pois" value="coffee,park" placeholder="coffee,park,bar" />
+          </label>
+          <div class="row" id="chrome">
+            <strong style="font-size:13px">Chrome:</strong>
+            <label class="chk"><input type="checkbox" data-chrome="legend" checked> Legend</label>
+            <label class="chk"><input type="checkbox" data-chrome="search" checked> Search</label>
+            <label class="chk"><input type="checkbox" data-chrome="help"> Help</label>
+            <label class="chk"><input type="checkbox" data-chrome="guide"> Guide link</label>
+            <label class="chk"><input type="checkbox" data-chrome="report"> Report</label>
+            <label class="chk"><input type="checkbox" data-chrome="locate" checked> Locate</label>
+          </div>
+          <div class="row">
+            <label class="chk"><input type="checkbox" id="dark"> Dark</label>
+            <label class="field">Units
+              <select id="units">
+                <option value="metric">Metric (km/m)</option>
+                <option value="imperial">Imperial (mi/ft)</option>
+              </select>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Copy-paste snippet</h2>
+    <pre><code id="snippet"></code></pre>
+    <button class="copy" id="copy">Copy snippet</button>
+
+    <h2>URL parameters</h2>
+    <div class="card table-scroll">
+      <table>
+        <thead><tr><th>Param</th><th>Values</th><th>Meaning</th></tr></thead>
+        <tbody>
+          <tr><td><code>embed</code></td><td><code>1</code></td><td>Master switch — enables embed mode.</td></tr>
+          <tr><td><code>legend</code>, <code>search</code></td><td><code>0</code>/<code>1</code></td><td>Show the legend / POI search (default on).</td></tr>
+          <tr><td><code>help</code>, <code>guide</code></td><td><code>0</code>/<code>1</code></td><td>Legend help button / wiki link (default off).</td></tr>
+          <tr><td><code>report</code>, <code>locate</code></td><td><code>0</code>/<code>1</code></td><td>POI report link (default off) / map locate control (default on).</td></tr>
+          <tr><td><code>hints</code></td><td><code>0</code>/<code>1</code></td><td>Onboarding overlay (default off in embed).</td></tr>
+          <tr><td><code>darktoggle</code>, <code>unitstoggle</code></td><td><code>0</code>/<code>1</code></td><td>Show the dark / units toggles in the legend (default on).</td></tr>
+          <tr><td><code>dark</code></td><td><code>0</code>/<code>1</code></td><td>Force light / dark. Omit to leave default (light).</td></tr>
+          <tr><td><code>units</code></td><td><code>metric</code>/<code>imperial</code></td><td>Distance units.</td></tr>
+          <tr><td><code>walkshed</code></td><td><code>5</code>/<code>10</code>/<code>15</code> (repeatable)</td><td>Which walkshed bands start enabled.</td></tr>
+          <tr><td><code>pois</code></td><td>e.g. <code>coffee,park</code></td><td>Initial POI filters.</td></tr>
+          <tr><td><code>origin</code></td><td>e.g. <code>https://host.example</code></td><td>Pin the postMessage peer origin (recommended).</td></tr>
+          <tr><td>path</td><td><code>/seattle/{line}/{stopCode}</code></td><td>Initial station, e.g. <code>/seattle/1/50</code> = <span class="pill"><span class="c" style="background:var(--line1)">1</span><span class="c" style="background:var(--line2)">2</span>&nbsp;Westlake</span>.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>postMessage protocol</h2>
+    <div class="card table-scroll">
+      <table>
+        <thead><tr><th>Direction</th><th>Message</th><th>Payload</th></tr></thead>
+        <tbody>
+          <tr><td>iframe → host</td><td><code>ready</code></td><td><code>{}</code> — fired once the map has loaded.</td></tr>
+          <tr><td>iframe → host</td><td><code>stationchange</code></td><td><code>{ name, line, stopCode, lines, lng, lat }</code></td></tr>
+          <tr><td>host → iframe</td><td><code>selectStation</code></td><td><code>{ line, stopCode }</code></td></tr>
+          <tr><td>host → iframe</td><td><code>setWalksheds</code></td><td><code>{ minutes: [5,10,15] }</code></td></tr>
+          <tr><td>host → iframe</td><td><code>setFilters</code></td><td><code>{ pois: "coffee,park" }</code></td></tr>
+          <tr><td>host → iframe</td><td><code>setDark</code></td><td><code>{ dark: true }</code></td></tr>
+          <tr><td>host → iframe</td><td><code>setUnits</code></td><td><code>{ units: "imperial" }</code></td></tr>
+        </tbody>
+      </table>
+      <p style="font-size:13px;color:var(--muted);margin:12px 4px 0">
+        Outbound messages carry <code>{ source: "walksheds", type, payload }</code>; inbound commands must
+        carry <code>{ source: "walksheds-host", type, payload }</code>. Set <code>origin</code> to pin the peer.
+        The <code>embed.js</code> helper wires all of this for you.
+      </p>
+    </div>
+  </div>
+
+  <script src="/embed.js"></script>
+  <script>
+    var widget = null
+    var statusEl = document.getElementById('status')
+
+    function readOpts() {
+      var chrome = {}
+      document.querySelectorAll('[data-chrome]').forEach(function (c) {
+        chrome[c.getAttribute('data-chrome')] = c.checked
+      })
+      var bands = []
+      document.querySelectorAll('#bands input:checked').forEach(function (b) { bands.push(Number(b.value)) })
+      return {
+        station: document.getElementById('station').value,
+        walkshed: bands,
+        pois: document.getElementById('pois').value.trim(),
+        dark: document.getElementById('dark').checked,
+        units: document.getElementById('units').value,
+        chrome: chrome,
+        origin: location.origin,
+      }
+    }
+
+    function snippetFor(opts) {
+      var pretty = {
+        station: opts.station,
+        walkshed: opts.walkshed,
+        pois: opts.pois,
+        dark: opts.dark,
+        units: opts.units,
+        chrome: opts.chrome,
+        origin: 'location.origin'
+      }
+      var json = JSON.stringify(pretty, null, 2).replace('"location.origin"', 'location.origin')
+      return '<div id="walksheds" style="max-width:720px"></div>\n' +
+        '<script src="https://walksheds.xyz/embed.js"><\/script>\n' +
+        '<script>\n' +
+        '  Walksheds.embed("#walksheds", ' + json.replace(/\n/g, '\n  ') + ');\n' +
+        '<\/script>'
+    }
+
+    function rebuild() {
+      var opts = readOpts()
+      document.getElementById('snippet').textContent = snippetFor(opts)
+      if (widget) widget.destroy()
+      statusEl.textContent = 'Loading…'
+      opts.height = 460
+      opts.onReady = function () { statusEl.textContent = 'Ready.' }
+      opts.onStationChange = function (s) { statusEl.textContent = 'Selected: ' + s.name + ' (' + s.stopCode + ')' }
+      widget = Walksheds.embed('#preview', opts)
+    }
+
+    document.querySelectorAll('select, input').forEach(function (el) {
+      el.addEventListener('change', rebuild)
+    })
+    document.getElementById('pois').addEventListener('input', function () {
+      document.getElementById('snippet').textContent = snippetFor(readOpts())
+    })
+    document.getElementById('copy').addEventListener('click', function () {
+      navigator.clipboard && navigator.clipboard.writeText(document.getElementById('snippet').textContent)
+      this.textContent = 'Copied'
+      var btn = this
+      setTimeout(function () { btn.textContent = 'Copy snippet' }, 1500)
+    })
+
+    rebuild()
+  </script>
+</body>
+</html>

--- a/public/embed.js
+++ b/public/embed.js
@@ -1,0 +1,126 @@
+/**
+ * Walksheds embed helper — drop the map into any page with one script.
+ *
+ *   <div id="map" style="max-width:720px"></div>
+ *   <script src="https://walksheds.xyz/embed.js"></script>
+ *   <script>
+ *     const w = Walksheds.embed('#map', {
+ *       station: 'seattle/1/50',      // or { line: '1', stopCode: 50 }
+ *       walkshed: [5, 10],            // enabled bands (minutes)
+ *       pois: 'coffee,park',          // POI filters
+ *       dark: false, units: 'metric',
+ *       chrome: { legend: true, search: true },
+ *       origin: location.origin,      // pin the postMessage peer (recommended)
+ *       onReady: () => {},
+ *       onStationChange: (s) => console.log(s.name),
+ *     })
+ *     // Drive it later:
+ *     w.select('2', 58)        // Bellevue Downtown
+ *     w.setWalksheds([5, 10, 15])
+ *     w.setFilters('coffee,bar')
+ *     w.setDark(true)
+ *     w.setUnits('imperial')
+ *   </script>
+ *
+ * Framework-free. The iframe is served from walksheds.xyz (keeping the Mapbox
+ * token valid) and isolates the app's CSS/JS from the host page. See
+ * https://wiki.walksheds.xyz/dev/ for the full protocol reference.
+ */
+(function (global) {
+  var DEFAULT_BASE = 'https://walksheds.xyz/'
+  var CHROME_KEYS = ['legend', 'search', 'hints', 'help', 'guide', 'report', 'locate', 'darkToggle', 'unitsToggle']
+  var CHROME_PARAM = {
+    legend: 'legend', search: 'search', hints: 'hints', help: 'help', guide: 'guide',
+    report: 'report', locate: 'locate', darkToggle: 'darktoggle', unitsToggle: 'unitstoggle',
+  }
+
+  function stationPath(station) {
+    if (!station) return ''
+    if (typeof station === 'string') return station.replace(/^\/+/, '')
+    if (station.line != null && station.stopCode != null) {
+      return 'seattle/' + station.line + '/' + station.stopCode
+    }
+    return ''
+  }
+
+  function buildEmbedUrl(opts) {
+    opts = opts || {}
+    var url = new URL(stationPath(opts.station), opts.base || DEFAULT_BASE)
+    var q = url.searchParams
+    q.set('embed', '1')
+
+    var chrome = opts.chrome || {}
+    CHROME_KEYS.forEach(function (key) {
+      if (chrome[key] != null) q.set(CHROME_PARAM[key], chrome[key] ? '1' : '0')
+    })
+    if (opts.dark != null) q.set('dark', opts.dark ? '1' : '0')
+    if (opts.units) q.set('units', opts.units)
+    if (opts.walkshed != null) {
+      [].concat(opts.walkshed).forEach(function (m) { q.append('walkshed', m) })
+    }
+    if (opts.pois != null && opts.pois !== '') {
+      q.set('pois', Array.isArray(opts.pois) ? opts.pois.join(',') : opts.pois)
+    }
+    if (opts.origin) q.set('origin', opts.origin)
+    return url.toString()
+  }
+
+  function embed(target, opts) {
+    opts = opts || {}
+    var el = typeof target === 'string' ? document.querySelector(target) : target
+    if (!el) throw new Error('Walksheds.embed: container "' + target + '" not found')
+
+    var src = buildEmbedUrl(opts)
+    var frameOrigin = new URL(src).origin
+
+    var wrap = document.createElement('div')
+    wrap.style.position = 'relative'
+    wrap.style.width = '100%'
+    if (opts.height != null) {
+      wrap.style.height = typeof opts.height === 'number' ? opts.height + 'px' : opts.height
+    } else {
+      // Responsive aspect box so the map keeps a sensible shape without a fixed height.
+      wrap.style.aspectRatio = opts.aspect ? String(opts.aspect) : '4 / 3'
+    }
+
+    var frame = document.createElement('iframe')
+    frame.src = src
+    frame.title = 'Walksheds — Seattle Link Light Rail walkshed explorer'
+    frame.loading = 'lazy'
+    frame.setAttribute('allow', 'geolocation; gyroscope; magnetometer')
+    frame.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;border:0;display:block'
+    wrap.appendChild(frame)
+    el.appendChild(wrap)
+
+    function onMessage(e) {
+      if (e.source !== frame.contentWindow) return
+      if (e.origin !== frameOrigin) return
+      var d = e.data
+      if (!d || d.source !== 'walksheds') return
+      if (d.type === 'ready' && opts.onReady) opts.onReady(d.payload)
+      else if (d.type === 'stationchange' && opts.onStationChange) opts.onStationChange(d.payload)
+    }
+    global.addEventListener('message', onMessage)
+
+    function post(type, payload) {
+      if (frame.contentWindow) {
+        frame.contentWindow.postMessage({ source: 'walksheds-host', type: type, payload: payload || {} }, frameOrigin)
+      }
+    }
+
+    return {
+      iframe: frame,
+      url: src,
+      select: function (line, stopCode) { post('selectStation', { line: line, stopCode: stopCode }) },
+      setWalksheds: function (minutes) { post('setWalksheds', { minutes: [].concat(minutes) }) },
+      setFilters: function (pois) { post('setFilters', { pois: Array.isArray(pois) ? pois.join(',') : pois }) },
+      setDark: function (dark) { post('setDark', { dark: !!dark }) },
+      setUnits: function (units) { post('setUnits', { units: units }) },
+      destroy: function () { global.removeEventListener('message', onMessage); wrap.remove() },
+    }
+  }
+
+  global.Walksheds = global.Walksheds || {}
+  global.Walksheds.embed = embed
+  global.Walksheds.buildEmbedUrl = buildEmbedUrl
+})(window);

--- a/src/LineLegend.jsx
+++ b/src/LineLegend.jsx
@@ -52,6 +52,9 @@ export default function LineLegend({
   onToggleCollapse,
   onHintsToggle,
   position,
+  showHelp = true,
+  showGuide = true,
+  showDark = true,
 }) {
   const posClass = position === 'bottom-right' ? 'bottom-right' : ''
   const touchStartY = useRef(null)
@@ -80,7 +83,8 @@ export default function LineLegend({
   if (collapsed) {
     return (
       <div className={`line-legend collapsed ${posClass}`} {...swipeProps}>
-        <button className="legend-dark-toggle-inline" onClick={onDarkModeToggle} aria-label="Toggle dark mode">
+        {showDark && (
+          <button className="legend-dark-toggle-inline" onClick={onDarkModeToggle} aria-label="Toggle dark mode">
             {darkMode ? (
               <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
                 <circle cx="8" cy="8" r="3.5" stroke="currentColor" strokeWidth="1.5"/>
@@ -92,23 +96,28 @@ export default function LineLegend({
               </svg>
             )}
           </button>
+        )}
           {onUnitsToggle && (
             <UnitsToggle units={units} onToggle={onUnitsToggle} className="legend-units-toggle-inline" />
           )}
-          <button className="legend-dark-toggle-inline" onClick={onHintsToggle} aria-label="Toggle hints" data-hint-keep="true">
-            {HELP_ICON}
-          </button>
-          <a
-            className="legend-dark-toggle-inline legend-wiki-link"
-            href={WIKI_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Open the Walksheds guide (opens in a new tab)"
-            title="Walksheds guide — wiki.walksheds.xyz"
-            data-hint-keep="true"
-          >
-            {WIKI_ICON}
-          </a>
+          {showHelp && (
+            <button className="legend-dark-toggle-inline" onClick={onHintsToggle} aria-label="Toggle hints" data-hint-keep="true">
+              {HELP_ICON}
+            </button>
+          )}
+          {showGuide && (
+            <a
+              className="legend-dark-toggle-inline legend-wiki-link"
+              href={WIKI_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open the Walksheds guide (opens in a new tab)"
+              title="Walksheds guide — wiki.walksheds.xyz"
+              data-hint-keep="true"
+            >
+              {WIKI_ICON}
+            </a>
+          )}
           <div className="legend-collapsed-divider" />
           <div className="legend-collapsed-walksheds">
             {WALKSHED_ITEMS.map(({ minutes }) => {
@@ -145,35 +154,41 @@ export default function LineLegend({
   return (
     <div className={`line-legend ${posClass}`} {...swipeProps}>
       <div className="legend-header">
-        <button className="legend-header-btn" onClick={onDarkModeToggle} aria-label="Toggle dark mode">
-          {darkMode ? (
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-              <circle cx="8" cy="8" r="3.5" stroke="currentColor" strokeWidth="1.5"/>
-              <path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.41 1.41M11.54 11.54l1.41 1.41M3.05 12.95l1.41-1.41M11.54 4.46l1.41-1.41" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-            </svg>
-          ) : (
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-              <path d="M14 9.6A6.5 6.5 0 016.4 2 6 6 0 1014 9.6z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-          )}
-        </button>
+        {showDark && (
+          <button className="legend-header-btn" onClick={onDarkModeToggle} aria-label="Toggle dark mode">
+            {darkMode ? (
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+                <circle cx="8" cy="8" r="3.5" stroke="currentColor" strokeWidth="1.5"/>
+                <path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.41 1.41M11.54 11.54l1.41 1.41M3.05 12.95l1.41-1.41M11.54 4.46l1.41-1.41" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+              </svg>
+            ) : (
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+                <path d="M14 9.6A6.5 6.5 0 016.4 2 6 6 0 1014 9.6z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            )}
+          </button>
+        )}
         {onUnitsToggle && (
           <UnitsToggle units={units} onToggle={onUnitsToggle} className="legend-header-btn legend-units-toggle" />
         )}
-        <button className="legend-header-btn" onClick={onHintsToggle} aria-label="Toggle hints" data-hint-keep="true">
-          {HELP_ICON}
-        </button>
-        <a
-          className="legend-header-btn legend-wiki-link"
-          href={WIKI_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Open the Walksheds guide (opens in a new tab)"
-          title="Walksheds guide — wiki.walksheds.xyz"
-          data-hint-keep="true"
-        >
-          {WIKI_ICON}
-        </a>
+        {showHelp && (
+          <button className="legend-header-btn" onClick={onHintsToggle} aria-label="Toggle hints" data-hint-keep="true">
+            {HELP_ICON}
+          </button>
+        )}
+        {showGuide && (
+          <a
+            className="legend-header-btn legend-wiki-link"
+            href={WIKI_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Open the Walksheds guide (opens in a new tab)"
+            title="Walksheds guide — wiki.walksheds.xyz"
+            data-hint-keep="true"
+          >
+            {WIKI_ICON}
+          </a>
+        )}
         <h3 className="legend-title">Legend</h3>
         <button className="legend-header-btn" onClick={onToggleCollapse} aria-label="Collapse legend" data-hint-keep="true">
           <svg width="12" height="12" viewBox="0 0 16 16" fill="none">

--- a/src/Walksheds.jsx
+++ b/src/Walksheds.jsx
@@ -15,6 +15,8 @@ import LineLegend from './LineLegend'
 import POISearch from './POISearch'
 import HintOverlay from './HintOverlay'
 import { shouldShowHints, markHintsSeen } from './hintsState'
+import { parseEmbedConfig } from './embedConfig'
+import { useEmbedBridge } from './embedBridge'
 import './walksheds.css'
 
 function computeSystemBounds(stationsData) {
@@ -79,6 +81,11 @@ function computeLegendPosition(map, walksheds, enabledWalksheds) {
 }
 
 export default function Walksheds() {
+  // Embed config, parsed once from the URL. When embedded, the app strips
+  // onboarding/branding chrome, stops writing to the URL + localStorage, and
+  // opens the postMessage bridge (see embedConfig.js / embedBridge.js).
+  const embed = useMemo(() => parseEmbedConfig(), [])
+
   const [popup, setPopup] = useState(null)
   const [walksheds, setWalksheds] = useState({})
   const [enabledWalksheds, setEnabledWalksheds] = useState(() => {
@@ -89,9 +96,15 @@ export default function Walksheds() {
   const [junctionHints, setJunctionHints] = useState([])
   const [terminusInfo, setTerminusInfo] = useState(null)
   const [darkMode, setDarkMode] = useState(() => {
+    // Embed: honor an explicit ?dark override, else default light and ignore
+    // localStorage (the frame shares the real site's storage — don't read stale).
+    if (embed.dark != null) return embed.dark
+    if (embed.embed) return false
     try { return window.localStorage.getItem('walksheds_dark_mode') === '1' } catch { return false }
   })
   const [units, setUnits] = useState(() => {
+    if (embed.units) return embed.units
+    if (embed.embed) return 'metric'
     try {
       const stored = window.localStorage.getItem('walksheds_units')
       return stored === 'imperial' ? 'imperial' : 'metric'
@@ -103,6 +116,9 @@ export default function Walksheds() {
   // Legend collapse: user preference (from localStorage or manual toggle) takes priority.
   // null = no preference, let auto-collapse decide based on overlap.
   const [userLegendPref, setUserLegendPref] = useState(() => {
+    // Embed: ignore the stored collapse preference; start expanded and let the
+    // walkshed-overlap auto-collapse decide.
+    if (embed.embed) return null
     try {
       const stored = window.localStorage.getItem('walksheds_legend_collapsed')
       if (stored !== null) return stored === '1'
@@ -115,18 +131,23 @@ export default function Walksheds() {
   const toggleLegendCollapsed = useCallback(() => {
     setUserLegendPref(prev => {
       const next = prev !== null ? !prev : !autoCollapsed
-      try { window.localStorage.setItem('walksheds_legend_collapsed', next ? '1' : '0') } catch { /* private mode */ }
+      // Don't persist in embed mode (shared origin storage).
+      if (!embed.embed) {
+        try { window.localStorage.setItem('walksheds_legend_collapsed', next ? '1' : '0') } catch { /* private mode */ }
+      }
       return next
     })
-  }, [autoCollapsed])
+  }, [autoCollapsed, embed])
 
   useEffect(() => {
+    if (embed.embed) return
     try { window.localStorage.setItem('walksheds_dark_mode', darkMode ? '1' : '0') } catch { /* private mode */ }
-  }, [darkMode])
+  }, [darkMode, embed])
 
   useEffect(() => {
+    if (embed.embed) return
     try { window.localStorage.setItem('walksheds_units', units) } catch { /* private mode */ }
-  }, [units])
+  }, [units, embed])
 
   const [legendPosition, setLegendPosition] = useState('bottom-left')
   const [hintsVisible, setHintsVisible] = useState(() => shouldShowHints())
@@ -214,6 +235,19 @@ export default function Walksheds() {
     }
   }, [enabledWalksheds, walksheds])
 
+  // Embed-bridge helper: set the enabled walkshed bands wholesale from a list
+  // of minutes (e.g. [5, 10]). Mirrors handleWalkshedToggle's legend reflow.
+  const applyWalksheds = useCallback((minutes) => {
+    const valid = new Set((Array.isArray(minutes) ? minutes : [])
+      .map(Number)
+      .filter(m => WALKSHED_OPTIONS.includes(m)))
+    setEnabledWalksheds(valid)
+    if (Object.keys(walksheds).length) {
+      const map = mapViewRef.current?.getMap()
+      setLegendPosition(computeLegendPosition(map, walksheds, valid))
+    }
+  }, [walksheds])
+
   // Compass orientation session (issue #16). Declared above selectStation
   // because every station navigation except the locate snap itself ends
   // the session — swiping to another station while the map rotates with
@@ -245,8 +279,9 @@ export default function Walksheds() {
     // it again (with skipFit) after this runs, so leave it intact in that case.
     if (!opts.skipFit) pendingExitFlyRef.current = null
 
-    // Sync URL
-    if (stopCode != null) {
+    // Sync URL (skipped in embed mode: the iframe src stays the stable source
+    // of truth set by the host).
+    if (stopCode != null && !embed.embed) {
       const base = import.meta.env.BASE_URL
       const lineNum = line.replace('-line', '')
       const schema = tagCategories?.filter_schema
@@ -287,7 +322,15 @@ export default function Walksheds() {
       setLegendPosition(computeLegendPosition(map, results, enabledWalksheds))
       setAutoCollapsed(legendOverlapsWalkshed(map, results, enabledWalksheds))
     })
-  }, [stationsData, enabledWalksheds, enabledSpotlights, activeCategories, activeFilters, tagCategories, compass])
+  }, [stationsData, enabledWalksheds, enabledSpotlights, activeCategories, activeFilters, tagCategories, compass, embed])
+
+  // Embed-bridge helper: select a station by line + stop code (e.g. '1', 50).
+  const selectStationByCode = useCallback((line, stopCode) => {
+    if (!stationsData) return
+    const station = findStationByCode(stationsData, String(line), Number(stopCode))
+    if (!station) return
+    selectStation(station.name, station.lng, station.lat, station.line)
+  }, [stationsData, selectStation])
 
   // Re-fit map when walkshed toggles change. But if a pending exit fly-to is
   // queued (a POI popup's station row was tapped), land on that exit once the
@@ -695,6 +738,7 @@ export default function Walksheds() {
   // codec uses a single tag namespace, so categories and filters are merged
   // here and routed back on parse.
   useEffect(() => {
+    if (embed.embed) return
     if (!selectedStationRef.current) return
     const feat = stationsData?.features.find(f => f.properties.name === selectedStationRef.current.name)
     if (!feat) return
@@ -708,7 +752,48 @@ export default function Walksheds() {
       buildPoiFilterParam(enabledSpotlights, mergedTags, schema, DEFAULT_ENABLED_MAIN_CATEGORIES),
     )
     window.history.replaceState(null, '', path)
-  }, [enabledWalksheds, enabledSpotlights, activeCategories, activeFilters, stationsData, currentLine, tagCategories])
+  }, [enabledWalksheds, enabledSpotlights, activeCategories, activeFilters, stationsData, currentLine, tagCategories, embed])
+
+  // Apply a parsed `?pois=` result (from parsePoiFilterParam) to the three
+  // filter state sets. Additive per bucket: only non-empty pieces are set, and
+  // a null parse seeds the default category pills — matching the initial
+  // restore below. Also reused by the embed bridge (applyPoiFilterString).
+  const applyPoiFilterState = useCallback((parsed) => {
+    if (parsed) {
+      if (parsed.categories.size) setEnabledSpotlights(parsed.categories)
+      if (parsed.tags.size) {
+        const cats = new Set()
+        const filts = new Set()
+        for (const t of parsed.tags) {
+          (isFilterTag(t) ? filts : cats).add(t)
+        }
+        if (cats.size) setActiveCategories(cats)
+        if (filts.size) setActiveFilters(filts)
+      }
+    } else {
+      setActiveCategories(new Set(DEFAULT_ENABLED_CATEGORY_TAGS))
+    }
+  }, [isFilterTag])
+
+  // Embed-bridge helper: replace the full filter state from a `?pois=`-style
+  // string (e.g. "coffee,park"). Unlike the additive restore, this is an
+  // explicit set so a host command can also clear filters (empty string).
+  const applyPoiFilterString = useCallback((str) => {
+    const schema = tagCategories?.filter_schema
+    const params = new URLSearchParams()
+    params.set('pois', str == null ? '' : String(str))
+    const parsed = parsePoiFilterParam('?' + params.toString(), schema)
+    const cats = new Set()
+    const filts = new Set()
+    let spotlights = new Set(DEFAULT_ENABLED_MAIN_CATEGORIES)
+    if (parsed) {
+      if (parsed.categories.size) spotlights = parsed.categories
+      for (const t of parsed.tags) (isFilterTag(t) ? filts : cats).add(t)
+    }
+    setEnabledSpotlights(spotlights)
+    setActiveCategories(cats)
+    setActiveFilters(filts)
+  }, [tagCategories, isFilterTag])
 
   // Restore POI filter state from `?pois=` once the schema is loaded.
   // Splits the parsed tag set into categories vs filters by the tag's
@@ -720,23 +805,8 @@ export default function Walksheds() {
     if (!tagCategories || poisResolvedRef.current) return
     poisResolvedRef.current = true
     const parsed = parsePoiFilterParam(window.location.search, tagCategories.filter_schema)
-    queueMicrotask(() => {
-      if (parsed) {
-        if (parsed.categories.size) setEnabledSpotlights(parsed.categories)
-        if (parsed.tags.size) {
-          const cats = new Set()
-          const filts = new Set()
-          for (const t of parsed.tags) {
-            (isFilterTag(t) ? filts : cats).add(t)
-          }
-          if (cats.size) setActiveCategories(cats)
-          if (filts.size) setActiveFilters(filts)
-        }
-      } else {
-        setActiveCategories(new Set(DEFAULT_ENABLED_CATEGORY_TAGS))
-      }
-    })
-  }, [tagCategories, isFilterTag])
+    queueMicrotask(() => applyPoiFilterState(parsed))
+  }, [tagCategories, applyPoiFilterState])
 
   useNavigation({
     graphRef,
@@ -798,8 +868,24 @@ export default function Walksheds() {
     })
   }, [])
 
+  // Two-way postMessage bridge for embedded views (no-op unless ?embed).
+  useEmbedBridge({
+    config: embed,
+    ready: !!stationsData,
+    api: { selectStationByCode, applyWalksheds, applyPoiFilterString, setDarkMode, setUnits },
+    popup,
+    currentLine,
+  })
+
   return (
-    <div className={`app ${darkMode ? 'dark' : ''} ${listOnTop ? 'list-on-top' : ''}`}>
+    <div className={[
+      'app',
+      darkMode && 'dark',
+      listOnTop && 'list-on-top',
+      embed.embed && 'embed',
+      !embed.chrome.report && 'embed-hide-report',
+      !embed.chrome.locate && 'embed-hide-locate',
+    ].filter(Boolean).join(' ')}>
       <MapView
         ref={mapViewRef}
         darkMode={darkMode}
@@ -835,7 +921,7 @@ export default function Walksheds() {
         units={units}
       />
 
-      {tagCategories && (
+      {embed.chrome.search && tagCategories && (
         <POISearch
           availableTags={availableTags}
           globalAvailableTags={globalAvailableTags}
@@ -859,20 +945,25 @@ export default function Walksheds() {
         />
       )}
 
-      <LineLegend
-        lineColors={LINE_COLORS}
-        enabledWalksheds={enabledWalksheds}
-        walkshedAccent={WALKSHED_ACCENT_LIGHT}
-        onWalkshedToggle={handleWalkshedToggle}
-        darkMode={darkMode}
-        onDarkModeToggle={() => setDarkMode(d => !d)}
-        units={units}
-        onUnitsToggle={() => setUnits(u => u === 'imperial' ? 'metric' : 'imperial')}
-        collapsed={legendCollapsed}
-        onToggleCollapse={() => toggleLegendCollapsed()}
-        onHintsToggle={handleHintsToggle}
-        position={legendPosition}
-      />
+      {embed.chrome.legend && (
+        <LineLegend
+          lineColors={LINE_COLORS}
+          enabledWalksheds={enabledWalksheds}
+          walkshedAccent={WALKSHED_ACCENT_LIGHT}
+          onWalkshedToggle={handleWalkshedToggle}
+          darkMode={darkMode}
+          onDarkModeToggle={() => setDarkMode(d => !d)}
+          units={units}
+          onUnitsToggle={embed.chrome.unitsToggle ? (() => setUnits(u => u === 'imperial' ? 'metric' : 'imperial')) : null}
+          collapsed={legendCollapsed}
+          onToggleCollapse={() => toggleLegendCollapsed()}
+          onHintsToggle={handleHintsToggle}
+          position={legendPosition}
+          showHelp={embed.chrome.help}
+          showGuide={embed.chrome.guide}
+          showDark={embed.chrome.darkToggle}
+        />
+      )}
 
       {hintsVisible && stationsData && <HintOverlay />}
     </div>

--- a/src/__tests__/embedBridge.test.js
+++ b/src/__tests__/embedBridge.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useEmbedBridge } from '../embedBridge'
+
+function cfg(overrides = {}) {
+  return { embed: true, chrome: {}, dark: null, units: null, origin: null, ...overrides }
+}
+
+function makeApi() {
+  return {
+    selectStationByCode: vi.fn(),
+    applyWalksheds: vi.fn(),
+    applyPoiFilterString: vi.fn(),
+    setDarkMode: vi.fn(),
+    setUnits: vi.fn(),
+  }
+}
+
+function send(data, origin = 'https://host.example') {
+  act(() => {
+    window.dispatchEvent(new MessageEvent('message', { data, origin }))
+  })
+}
+
+let postSpy
+beforeEach(() => {
+  postSpy = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useEmbedBridge outbound', () => {
+  it('posts ready on mount once station data is ready', () => {
+    renderHook(() => useEmbedBridge({ config: cfg(), ready: true, api: makeApi(), popup: null, currentLine: null }))
+    expect(postSpy).toHaveBeenCalledWith(
+      { source: 'walksheds', type: 'ready', payload: {} },
+      '*',
+    )
+  })
+
+  it('pins the target origin when config.origin is set', () => {
+    renderHook(() => useEmbedBridge({
+      config: cfg({ origin: 'https://host.example' }),
+      ready: true, api: makeApi(), popup: null, currentLine: null,
+    }))
+    expect(postSpy).toHaveBeenCalledWith(expect.anything(), 'https://host.example')
+  })
+
+  it('emits stationchange when the selected station changes', () => {
+    const { rerender } = renderHook(
+      ({ popup }) => useEmbedBridge({ config: cfg(), ready: true, api: makeApi(), popup, currentLine: '1-line' }),
+      { initialProps: { popup: null } },
+    )
+    postSpy.mockClear()
+    rerender({ popup: { name: 'Westlake Station', stopCode: 50, lines: '1,2', longitude: -122.3, latitude: 47.6, line: '1-line' } })
+    expect(postSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'walksheds',
+        type: 'stationchange',
+        payload: expect.objectContaining({ name: 'Westlake Station', line: '1', stopCode: 50 }),
+      }),
+      '*',
+    )
+  })
+
+  it('does nothing when not embedded', () => {
+    const api = makeApi()
+    renderHook(() => useEmbedBridge({ config: cfg({ embed: false }), ready: true, api, popup: null, currentLine: null }))
+    expect(postSpy).not.toHaveBeenCalled()
+    send({ source: 'walksheds-host', type: 'selectStation', payload: { line: '1', stopCode: 50 } })
+    expect(api.selectStationByCode).not.toHaveBeenCalled()
+  })
+})
+
+describe('useEmbedBridge inbound', () => {
+  it('dispatches each whitelisted command to the api', () => {
+    const api = makeApi()
+    renderHook(() => useEmbedBridge({ config: cfg(), ready: true, api, popup: null, currentLine: null }))
+
+    send({ source: 'walksheds-host', type: 'selectStation', payload: { line: '1', stopCode: 50 } })
+    expect(api.selectStationByCode).toHaveBeenCalledWith('1', 50)
+
+    send({ source: 'walksheds-host', type: 'setWalksheds', payload: { minutes: [5, 10] } })
+    expect(api.applyWalksheds).toHaveBeenCalledWith([5, 10])
+
+    send({ source: 'walksheds-host', type: 'setFilters', payload: { pois: 'coffee,park' } })
+    expect(api.applyPoiFilterString).toHaveBeenCalledWith('coffee,park')
+
+    send({ source: 'walksheds-host', type: 'setDark', payload: { dark: true } })
+    expect(api.setDarkMode).toHaveBeenCalledWith(true)
+
+    send({ source: 'walksheds-host', type: 'setUnits', payload: { units: 'imperial' } })
+    expect(api.setUnits).toHaveBeenCalledWith('imperial')
+  })
+
+  it('ignores messages without the walksheds-host source (namespace guard)', () => {
+    const api = makeApi()
+    renderHook(() => useEmbedBridge({ config: cfg(), ready: true, api, popup: null, currentLine: null }))
+    send({ source: 'someone-else', type: 'selectStation', payload: { line: '1', stopCode: 50 } })
+    send({ type: 'selectStation', payload: { line: '1', stopCode: 50 } })
+    expect(api.selectStationByCode).not.toHaveBeenCalled()
+  })
+
+  it('enforces the origin allowlist when config.origin is set', () => {
+    const api = makeApi()
+    renderHook(() => useEmbedBridge({
+      config: cfg({ origin: 'https://host.example' }),
+      ready: true, api, popup: null, currentLine: null,
+    }))
+    send({ source: 'walksheds-host', type: 'setDark', payload: { dark: true } }, 'https://evil.example')
+    expect(api.setDarkMode).not.toHaveBeenCalled()
+    send({ source: 'walksheds-host', type: 'setDark', payload: { dark: true } }, 'https://host.example')
+    expect(api.setDarkMode).toHaveBeenCalledWith(true)
+  })
+
+  it('ignores unknown command types without throwing', () => {
+    const api = makeApi()
+    renderHook(() => useEmbedBridge({ config: cfg(), ready: true, api, popup: null, currentLine: null }))
+    expect(() => send({ source: 'walksheds-host', type: 'launchMissiles', payload: {} })).not.toThrow()
+    for (const fn of Object.values(api)) expect(fn).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/embedConfig.test.js
+++ b/src/__tests__/embedConfig.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { parseEmbedConfig } from '../embedConfig'
+
+describe('parseEmbedConfig', () => {
+  it('returns non-embed defaults when ?embed is absent (app unchanged)', () => {
+    const c = parseEmbedConfig('')
+    expect(c.embed).toBe(false)
+    // Every affordance visible; no value overrides.
+    for (const key of Object.keys(c.chrome)) expect(c.chrome[key]).toBe(true)
+    expect(c.dark).toBeNull()
+    expect(c.units).toBeNull()
+    expect(c.origin).toBeNull()
+  })
+
+  it('enables embed via bare ?embed and ?embed=1', () => {
+    expect(parseEmbedConfig('?embed').embed).toBe(true)
+    expect(parseEmbedConfig('?embed=1').embed).toBe(true)
+    expect(parseEmbedConfig('?embed=0').embed).toBe(false)
+    expect(parseEmbedConfig('?embed=false').embed).toBe(false)
+  })
+
+  it('applies embed chrome defaults: onboarding/branding hidden, map+controls shown', () => {
+    const { chrome } = parseEmbedConfig('?embed=1')
+    expect(chrome.hints).toBe(false)
+    expect(chrome.help).toBe(false)
+    expect(chrome.guide).toBe(false)
+    expect(chrome.report).toBe(false)
+    expect(chrome.legend).toBe(true)
+    expect(chrome.search).toBe(true)
+    expect(chrome.locate).toBe(true)
+    expect(chrome.darkToggle).toBe(true)
+    expect(chrome.unitsToggle).toBe(true)
+  })
+
+  it('honors per-flag chrome overrides', () => {
+    const { chrome } = parseEmbedConfig('?embed=1&legend=0&search=0&help=1&locate=0')
+    expect(chrome.legend).toBe(false)
+    expect(chrome.search).toBe(false)
+    expect(chrome.help).toBe(true)
+    expect(chrome.locate).toBe(false)
+  })
+
+  it('parses dark and units value overrides', () => {
+    const c = parseEmbedConfig('?embed=1&dark=1&units=imperial')
+    expect(c.dark).toBe(true)
+    expect(c.units).toBe('imperial')
+
+    expect(parseEmbedConfig('?embed=1&dark=0').dark).toBe(false)
+    expect(parseEmbedConfig('?embed=1&units=metric').units).toBe('metric')
+  })
+
+  it('leaves overrides null when absent or invalid', () => {
+    const c = parseEmbedConfig('?embed=1&units=furlongs')
+    expect(c.dark).toBeNull()
+    expect(c.units).toBeNull()
+  })
+
+  it('validates the origin param', () => {
+    expect(parseEmbedConfig('?embed=1&origin=https://host.example').origin)
+      .toBe('https://host.example')
+    expect(parseEmbedConfig('?embed=1&origin=not-a-url').origin).toBeNull()
+    expect(parseEmbedConfig('?embed=1').origin).toBeNull()
+  })
+
+  it('returns a frozen config and frozen chrome', () => {
+    const c = parseEmbedConfig('?embed=1')
+    expect(Object.isFrozen(c)).toBe(true)
+    expect(Object.isFrozen(c.chrome)).toBe(true)
+  })
+})

--- a/src/__tests__/embedMode.test.jsx
+++ b/src/__tests__/embedMode.test.jsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const emptyFC = { type: 'FeatureCollection', features: [] }
+const TAG_CATEGORIES = {
+  categories: {},
+  tag_to_category: {},
+  filter_tag_categories: [],
+  filter_schema: { cat: {}, tag: {}, aliases: {} },
+}
+
+// URL-aware fetch: tag-categories.json returns a minimal schema (so POISearch
+// mounts); everything else returns an empty FeatureCollection.
+beforeEach(() => {
+  globalThis.fetch = vi.fn((url) => {
+    const body = String(url).includes('tag-categories') ? TAG_CATEGORIES : emptyFC
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(body) })
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  window.localStorage.clear()
+})
+
+vi.mock('mapbox-gl', () => ({
+  default: { Map: vi.fn(), NavigationControl: vi.fn(), supported: () => true },
+}))
+
+vi.mock('react-map-gl', () => ({
+  default: ({ children }) => <div data-testid="map">{children}</div>,
+  Source: ({ children }) => <div>{children}</div>,
+  Layer: () => null,
+  Marker: ({ children }) => <div>{children}</div>,
+  GeolocateControl: () => null,
+}))
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import Walksheds from '../Walksheds'
+
+function setLocation(search = '', pathname = '/') {
+  delete window.location
+  window.location = {
+    pathname,
+    search,
+    hash: '',
+    href: `http://localhost${pathname}${search}`,
+    origin: 'http://localhost',
+  }
+}
+
+describe('embed mode rendering', () => {
+  it('strips onboarding + branding chrome but keeps the map, legend and search', async () => {
+    setLocation('?embed=1')
+    const { container } = render(<Walksheds />)
+
+    expect(screen.getByTestId('map')).toBeTruthy()
+    expect(container.querySelector('.app').classList.contains('embed')).toBe(true)
+    // Legend present; search mounts once tag categories load.
+    expect(container.querySelector('.line-legend')).toBeTruthy()
+    await waitFor(() => expect(container.querySelector('.poi-search')).toBeTruthy())
+    // Onboarding + branding gone.
+    expect(container.querySelector('.hint-overlay')).toBeNull()
+    expect(container.querySelector('[aria-label="Toggle hints"]')).toBeNull()
+    expect(container.querySelector('.legend-wiki-link')).toBeNull()
+    // Report + locate hidden via .app modifier classes.
+    expect(container.querySelector('.app').classList.contains('embed-hide-report')).toBe(true)
+    expect(container.querySelector('.app').classList.contains('embed-hide-locate')).toBe(false)
+  })
+
+  it('honors ?legend=0 (JSX gate) and ?search=0', async () => {
+    setLocation('?embed=1&legend=0&search=0')
+    const { container } = render(<Walksheds />)
+    // Legend is always-rendered outside embed, so its absence proves the gate.
+    expect(container.querySelector('.line-legend')).toBeNull()
+    // Give tag categories a chance to load; search must still be gated out.
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled())
+    expect(container.querySelector('.poi-search')).toBeNull()
+  })
+
+  it('honors ?locate=0', () => {
+    setLocation('?embed=1&locate=0')
+    const { container } = render(<Walksheds />)
+    expect(container.querySelector('.app').classList.contains('embed-hide-locate')).toBe(true)
+  })
+
+  it('applies ?dark=1 without writing localStorage (shared origin)', () => {
+    setLocation('?embed=1&dark=1')
+    const { container } = render(<Walksheds />)
+    expect(container.querySelector('.app').classList.contains('dark')).toBe(true)
+    expect(window.localStorage.getItem('walksheds_dark_mode')).toBeNull()
+  })
+
+  it('does not persist a dark toggle keypress in embed mode', () => {
+    setLocation('?embed=1')
+    render(<Walksheds />)
+    fireEvent.keyDown(window, { key: 'd' })
+    expect(window.localStorage.getItem('walksheds_dark_mode')).toBeNull()
+  })
+
+  it('non-embed control keeps the help button + wiki link and no embed class', () => {
+    setLocation('')
+    const { container } = render(<Walksheds />)
+    expect(container.querySelector('.app').classList.contains('embed')).toBe(false)
+    expect(container.querySelector('[aria-label="Toggle hints"]')).toBeTruthy()
+    expect(container.querySelector('.legend-wiki-link')).toBeTruthy()
+  })
+})

--- a/src/__tests__/hintsState.test.js
+++ b/src/__tests__/hintsState.test.js
@@ -48,6 +48,16 @@ describe('shouldShowHints', () => {
     setLocation({ pathname: '/seattle/1/50', search: '?hints' })
     expect(shouldShowHints()).toBe(true)
   })
+
+  it('returns false in embed mode', () => {
+    setLocation({ search: '?embed=1' })
+    expect(shouldShowHints()).toBe(false)
+  })
+
+  it('lets ?hints override embed mode', () => {
+    setLocation({ search: '?embed=1&hints' })
+    expect(shouldShowHints()).toBe(true)
+  })
 })
 
 describe('markHintsSeen', () => {

--- a/src/embedBridge.js
+++ b/src/embedBridge.js
@@ -1,0 +1,111 @@
+/**
+ * Two-way postMessage bridge for embedded Walksheds (see embedConfig.js).
+ *
+ * Only active when `config.embed` is true. It:
+ *   - emits outbound events to the parent frame: `ready` (once station data
+ *     loads) and `stationchange` (whenever the selected station changes);
+ *   - accepts a fixed, non-destructive inbound command whitelist from the host.
+ *
+ * Message shapes:
+ *   outbound  { source: 'walksheds',      type, payload }
+ *   inbound   { source: 'walksheds-host', type, payload }
+ *
+ * Security: inbound messages are accepted only when tagged with the
+ * `walksheds-host` source and (if `config.origin` is pinned via ?origin=) from
+ * that exact origin. Every command only mutates map/filter React state — it
+ * never touches storage, navigation, or the host window — so the surface is a
+ * whitelist by construction. Outbound payloads carry only public map data, so
+ * the default target origin is '*'; a host can pin it with ?origin=.
+ */
+
+import { useCallback, useEffect, useRef } from 'react'
+
+const OUTBOUND_SOURCE = 'walksheds'
+const INBOUND_SOURCE = 'walksheds-host'
+
+/**
+ * @param {object}   opts
+ * @param {object}   opts.config       parsed embed config (embedConfig.js)
+ * @param {boolean}  opts.ready        true once station data has loaded
+ * @param {object}   opts.api          { selectStationByCode, applyWalksheds,
+ *                                        applyPoiFilterString, setDarkMode, setUnits }
+ * @param {object}   opts.popup        current station popup (or null)
+ * @param {string}   opts.currentLine  current line id (e.g. '1-line')
+ */
+export function useEmbedBridge({ config, ready, api, popup, currentLine }) {
+  const enabled = !!config?.embed
+  const pinnedOrigin = config?.origin || null
+  const targetOrigin = pinnedOrigin || '*'
+
+  // Keep the latest api without re-subscribing the message listener.
+  const apiRef = useRef(api)
+  useEffect(() => { apiRef.current = api })
+
+  const post = useCallback((type, payload) => {
+    if (!enabled || typeof window === 'undefined') return
+    try {
+      window.parent.postMessage({ source: OUTBOUND_SOURCE, type, payload }, targetOrigin)
+    } catch {
+      /* postMessage can throw in exotic cross-origin cases; ignore */
+    }
+  }, [enabled, targetOrigin])
+
+  // Inbound command listener.
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return
+    const onMessage = (event) => {
+      const data = event.data
+      if (!data || data.source !== INBOUND_SOURCE || typeof data.type !== 'string') return
+      if (pinnedOrigin && event.origin !== pinnedOrigin) return
+      const payload = data.payload || {}
+      const a = apiRef.current || {}
+      switch (data.type) {
+        case 'selectStation':
+          if (payload.line != null && payload.stopCode != null) {
+            a.selectStationByCode?.(payload.line, payload.stopCode)
+          }
+          break
+        case 'setWalksheds':
+          a.applyWalksheds?.(payload.minutes)
+          break
+        case 'setFilters':
+          a.applyPoiFilterString?.(payload.pois ?? '')
+          break
+        case 'setDark':
+          a.setDarkMode?.(!!payload.dark)
+          break
+        case 'setUnits':
+          if (payload.units === 'metric' || payload.units === 'imperial') {
+            a.setUnits?.(payload.units)
+          }
+          break
+        default:
+          break // unknown command: ignore silently
+      }
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [enabled, pinnedOrigin])
+
+  // Emit `ready` once station data has loaded.
+  const readySentRef = useRef(false)
+  useEffect(() => {
+    if (!enabled || !ready || readySentRef.current) return
+    readySentRef.current = true
+    post('ready', {})
+  }, [enabled, ready, post])
+
+  // Emit `stationchange` whenever the selected station changes.
+  useEffect(() => {
+    if (!enabled || !popup) return
+    const lineId = currentLine || popup.line || ''
+    post('stationchange', {
+      name: popup.name,
+      line: lineId.replace('-line', ''),
+      stopCode: popup.stopCode,
+      lines: popup.lines,
+      lng: popup.longitude,
+      lat: popup.latitude,
+    })
+  }, [enabled, popup, currentLine, post])
+}

--- a/src/embedConfig.js
+++ b/src/embedConfig.js
@@ -1,0 +1,136 @@
+/**
+ * Embed-mode configuration, parsed once from the URL query at startup.
+ *
+ * Walksheds is embedded by framing the live site with `?embed=1` (see
+ * public/embed.js + public/embed.html + wiki/docs/embedding.md). Embed mode
+ * strips onboarding/branding chrome, stops writing to the URL and localStorage
+ * (the iframe runs on the walksheds.xyz origin, so its localStorage is shared
+ * with the real site — an embed must not flip a visitor's stored prefs), and
+ * opens the two-way postMessage bridge (see embedBridge.js).
+ *
+ * The config is a frozen, side-effect-free snapshot: `parseEmbedConfig` only
+ * reads the query string, never touches history/storage.
+ *
+ * Query params (all optional; only read when `embed` is present):
+ *   embed            master switch (?embed or ?embed=1)
+ *   legend/search    show the legend / POI search (default on)
+ *   hints            show onboarding overlay (default off in embed)
+ *   help/guide       show the legend's help button / wiki link (default off)
+ *   report/locate    show the POI report link / map locate control
+ *                    (report default off, locate default on)
+ *   darktoggle       show the legend dark-mode toggle (default on)
+ *   unitstoggle      show the legend units (m/ft) toggle (default on)
+ *   dark             force dark (1) or light (0); absent = no override
+ *   units            force 'metric' or 'imperial'; absent = no override
+ *   origin           pin the postMessage peer origin (e.g. https://host.example)
+ *
+ * Existing params still drive initial state in embed mode: the deep-link path
+ * `/seattle/{line}/{stopCode}`, `?walkshed=`, and `?pois=`.
+ */
+
+// Chrome visibility defaults. In embed mode we hide onboarding and branding by
+// default; a per-flag param (?embed=1&help=1) overrides any single default.
+const CHROME_DEFAULTS_EMBED = {
+  legend: true,
+  search: true,
+  hints: false,
+  help: false,
+  guide: false,
+  report: false,
+  locate: true,
+  darkToggle: true,
+  unitsToggle: true,
+}
+
+// Outside embed mode every affordance shows and nothing is suppressed, so the
+// normal app is byte-for-byte unchanged.
+const CHROME_DEFAULTS_NORMAL = {
+  legend: true,
+  search: true,
+  hints: true,
+  help: true,
+  guide: true,
+  report: true,
+  locate: true,
+  darkToggle: true,
+  unitsToggle: true,
+}
+
+// URL param name (lowercase) → chrome key.
+const CHROME_PARAM = {
+  legend: 'legend',
+  search: 'search',
+  hints: 'hints',
+  help: 'help',
+  guide: 'guide',
+  report: 'report',
+  locate: 'locate',
+  darktoggle: 'darkToggle',
+  unitstoggle: 'unitsToggle',
+}
+
+// Parse a boolean-ish flag. A bare flag (?help) or truthy string counts as
+// true; explicit 0/false/no as false; anything else falls back to `dflt`.
+function parseBool(value, dflt) {
+  if (value == null) return dflt
+  const s = String(value).trim().toLowerCase()
+  if (s === '' || s === '1' || s === 'true' || s === 'yes' || s === 'on') return true
+  if (s === '0' || s === 'false' || s === 'no' || s === 'off') return false
+  return dflt
+}
+
+// Validate an origin string; return the canonical origin or null.
+function parseOrigin(value) {
+  if (!value) return null
+  try {
+    const origin = new URL(value).origin
+    return origin && origin !== 'null' ? origin : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse embed config from a query string (defaults to the live location).
+ * Returns a frozen object; when not embedded, `chrome` is the all-visible
+ * default set so callers can read `config.chrome.*` unconditionally.
+ */
+export function parseEmbedConfig(search) {
+  const query = search != null
+    ? search
+    : (typeof window !== 'undefined' ? window.location.search : '')
+  const params = new URLSearchParams(query)
+
+  const embed = params.has('embed') && parseBool(params.get('embed'), true)
+  if (!embed) {
+    return Object.freeze({
+      embed: false,
+      chrome: Object.freeze({ ...CHROME_DEFAULTS_NORMAL }),
+      dark: null,
+      units: null,
+      origin: null,
+    })
+  }
+
+  const chrome = {}
+  for (const [param, key] of Object.entries(CHROME_PARAM)) {
+    chrome[key] = parseBool(params.get(param), CHROME_DEFAULTS_EMBED[key])
+  }
+
+  let dark = null
+  if (params.has('dark')) dark = parseBool(params.get('dark'), true)
+
+  let units = null
+  if (params.has('units')) {
+    const u = String(params.get('units')).trim().toLowerCase()
+    if (u === 'metric' || u === 'imperial') units = u
+  }
+
+  return Object.freeze({
+    embed: true,
+    chrome: Object.freeze(chrome),
+    dark,
+    units,
+    origin: parseOrigin(params.get('origin')),
+  })
+}

--- a/src/hintsState.js
+++ b/src/hintsState.js
@@ -16,6 +16,8 @@ export function shouldShowHints() {
   // ?hints forces hints regardless of storage or deep link
   const params = new URLSearchParams(window.location.search)
   if (params.has('hints')) return true
+  // Embedded views never show onboarding (unless ?hints forced it above).
+  if (params.has('embed')) return false
   const ls = safeStorage()
   if (ls && ls.getItem(STORAGE_KEY)) return false
   // Skip hints for deep-linked visits — shared links shouldn't surface onboarding

--- a/src/walksheds.css
+++ b/src/walksheds.css
@@ -27,6 +27,18 @@ body,
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
+/* ── Embed mode (see embedConfig.js) ──
+   Chrome that lives too deep to prop-drill cleanly is hidden by class on the
+   root .app: the POI report link and the Mapbox locate control. Top-level
+   chrome (legend, search, onboarding) is gated in JSX instead. */
+.app.embed-hide-report .poi-popup-report {
+  display: none;
+}
+
+.app.embed-hide-locate .mapboxgl-ctrl-geolocate {
+  display: none;
+}
+
 /* ── Line Legend ── */
 
 .line-legend {

--- a/wiki/codex/docs/embedding.md
+++ b/wiki/codex/docs/embedding.md
@@ -1,0 +1,116 @@
+# Embedding Walksheds
+
+Walksheds can be embedded in another site or dashboard as an **iframe** served
+from `walksheds.xyz`. Framing the live site (rather than shipping a JS bundle)
+keeps the origin-restricted Mapbox token valid and isolates the app's CSS and
+global state from the host page.
+
+There are two ways in: a copy-paste **helper script** (recommended) or a plain
+**iframe** with query parameters. A live demo + snippet generator is served at
+<https://walksheds.xyz/embed.html>.
+
+## Quick start (helper script)
+
+```html
+<div id="walksheds" style="max-width:720px"></div>
+<script src="https://walksheds.xyz/embed.js"></script>
+<script>
+  const w = Walksheds.embed('#walksheds', {
+    station: 'seattle/1/50',      // or { line: '1', stopCode: 50 }
+    walkshed: [5, 10],            // enabled bands (minutes)
+    pois: 'coffee,park',          // POI filters
+    dark: false, units: 'metric',
+    chrome: { legend: true, search: true },
+    origin: location.origin,      // pin the postMessage peer (recommended)
+    onReady: () => {},
+    onStationChange: (s) => console.log(s.name),
+  })
+
+  // Drive it later:
+  w.select('2', 58)               // Bellevue Downtown
+  w.setWalksheds([5, 10, 15])
+  w.setFilters('coffee,bar')
+  w.setDark(true)
+  w.setUnits('imperial')
+</script>
+```
+
+`embed.js` builds the iframe, injects a responsive aspect-ratio box (pass
+`height` for a fixed height instead), and wires the two-way `postMessage`
+bridge to your callbacks and the returned control handle.
+
+## Plain iframe
+
+```html
+<iframe
+  src="https://walksheds.xyz/seattle/1/50?embed=1&walkshed=5&walkshed=10&pois=coffee,park"
+  style="width:100%;aspect-ratio:4/3;border:0"
+  allow="geolocation; gyroscope; magnetometer"
+  loading="lazy"
+  title="Walksheds"></iframe>
+```
+
+## Embed mode
+
+`?embed=1` switches the app into embed mode, which:
+
+- **strips onboarding + branding chrome** by default (see the flag table);
+- **stops writing to the URL and to `localStorage`** — the iframe `src` stays
+  the source of truth, and (because the frame shares `walksheds.xyz` storage
+  with the real site) an embed never flips a visitor's saved preferences;
+- **opens the `postMessage` bridge** for host control.
+
+Initial state still hydrates from the URL you set: the deep-link path
+`/seattle/{line}/{stopCode}`, `?walkshed=`, and `?pois=`.
+
+## URL parameters
+
+| Param | Values | Meaning |
+|---|---|---|
+| `embed` | `1` | Master switch — enables embed mode. |
+| `legend`, `search` | `0`/`1` | Show the legend / POI search (default on). |
+| `help`, `guide` | `0`/`1` | Legend help button / wiki link (default off in embed). |
+| `report`, `locate` | `0`/`1` | POI report link (default off) / map locate control (default on). |
+| `hints` | `0`/`1` | Onboarding overlay (default off in embed). |
+| `darktoggle`, `unitstoggle` | `0`/`1` | Show the dark / units toggles in the legend (default on). |
+| `dark` | `0`/`1` | Force light / dark. Omit for the default (light). |
+| `units` | `metric`/`imperial` | Distance units. |
+| `walkshed` | `5`/`10`/`15` (repeatable) | Which walkshed bands start enabled. |
+| `pois` | e.g. `coffee,park` | Initial POI filters. |
+| `origin` | e.g. `https://host.example` | Pin the postMessage peer origin. |
+| path | `/seattle/{line}/{stopCode}` | Initial station, e.g. `/seattle/1/50` (Westlake). |
+
+## postMessage protocol
+
+Outbound messages (iframe → host) carry `{ source: 'walksheds', type, payload }`;
+inbound commands (host → iframe) must carry `{ source: 'walksheds-host', type,
+payload }`.
+
+| Direction | Message | Payload |
+|---|---|---|
+| iframe → host | `ready` | `{}` — once the map has loaded |
+| iframe → host | `stationchange` | `{ name, line, stopCode, lines, lng, lat }` |
+| host → iframe | `selectStation` | `{ line, stopCode }` |
+| host → iframe | `setWalksheds` | `{ minutes: [5,10,15] }` |
+| host → iframe | `setFilters` | `{ pois: "coffee,park" }` |
+| host → iframe | `setDark` | `{ dark: true }` |
+| host → iframe | `setUnits` | `{ units: "imperial" }` |
+
+### Security
+
+Inbound commands are accepted only when tagged with the `walksheds-host`
+source and — if you set `origin` — from that exact origin. Every command only
+mutates map/filter state; none touch storage, navigation, or the host window,
+so the surface is a whitelist by construction. Outbound payloads carry only
+public map data, so the default outbound target origin is `*`; pin it with
+`origin` when embedding on a known host.
+
+## Implementation
+
+- `src/embedConfig.js` — parses `?embed` + flags into a frozen config.
+- `src/embedBridge.js` — the `useEmbedBridge` hook (outbound events + inbound
+  command whitelist).
+- `src/Walksheds.jsx` — threads the config: init overrides, skipped URL/storage
+  writes, chrome gating.
+- `public/embed.js` — framework-free host helper.
+- `public/embed.html` — live demo + snippet generator.

--- a/wiki/codex/mkdocs.yml
+++ b/wiki/codex/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - Station exits: data/station-exits.md
   - Core invariants: invariants.md
   - Commands: commands.md
+  - Embedding: embedding.md
   - Deployment + DNS: deployment.md
   - Station codes: station-codes.md
   - Contributing: contributing.md


### PR DESCRIPTION
*Feature · Embedding*

# Drop Walksheds into any site or dashboard as an iframe

> **TL;DR** The app had no embed surface — no `?embed`, no `postMessage`, no way for another site to host or control it. This adds an `?embed=1` mode with a documented URL-param config API and a two-way `postMessage` bridge, plus a framework-free host helper and a live demo/snippet generator. iframe (not a JS bundle) because the Mapbox token is origin-restricted to `walksheds.xyz` and framing isolates the app's CSS/global state from the host page.

> [!NOTE]
> **Area** embed mode, legend, POI card, docs · **Type** feature · **Risk** low (non-embed path unchanged; new code is gated on `?embed`)

## Why & what

Slackbot-style crawlers aside, dashboards embed maps by iframe. Walksheds is already URL-driven, so most of the work is a clean embed mode that strips chrome and stops fighting the host for the URL/storage.

- **`src/embedConfig.js`** — `parseEmbedConfig()` → frozen config: per-flag chrome toggles (`legend/search/help/guide/report/locate` + dark/units toggles), `dark`/`units` value overrides, and an optional `origin`. Outside embed, everything defaults visible so the normal app is unchanged.
- **`src/embedBridge.js`** — `useEmbedBridge` hook. Outbound `ready` / `stationchange`; inbound whitelist `selectStation` / `setWalksheds` / `setFilters` / `setDark` / `setUnits`, guarded by a `walksheds-host` namespace and (when `?origin` is set) an origin allowlist. Every command only mutates map/filter state — no storage, navigation, or host-window access.
- **`src/Walksheds.jsx`** — threads the config: init dark/units from overrides, **skip URL + localStorage writes in embed** (the frame shares the real site's origin storage; the iframe `src` stays the source of truth), suppress onboarding, gate chrome. Extracted `applyPoiFilterState` / `applyWalksheds` / `selectStationByCode` (no behavior change) so the bridge reuses existing handlers/codecs.
- **`src/LineLegend.jsx`** — `showHelp` / `showGuide` / `showDark` props gate the help button, wiki link, and dark toggle. **`src/walksheds.css`** — `.app.embed-hide-report` / `.app.embed-hide-locate` hide the deep-tree leaves.
- **`public/embed.js`** — `Walksheds.embed(el, opts)` builds the iframe + wires the bridge. **`public/embed.html`** — live preview + copy-paste snippet generator + full param/protocol reference. Both ship in `dist/` automatically.
- **Docs** — `wiki/codex/docs/embedding.md` (+ nav), README + CLAUDE.md pointers.

## Flow

```mermaid
flowchart LR
  H[Host page] -->|Walksheds.embed / iframe ?embed=1| F[iframe @ walksheds.xyz]
  F -->|ready, stationchange| H
  H -->|selectStation, setWalksheds, setFilters, setDark, setUnits| F
  CFG[embedConfig] --> F
  F --> BR[useEmbedBridge]
```

## Verify & risk

- `npm run test -- --run` — **390 pass** (+24: `embedConfig`, `embedBridge`, `embedMode`, `hintsState`); `npm run lint` + `npm run build` clean; `dist/embed.js` + `dist/embed.html` ship.
- Verified the built artifact in a browser: `?embed=1&dark=1` → `.app` = `app dark embed embed-hide-report`, legend present, help/wiki/onboarding gone; `?embed=1&legend=0&search=0` → map only; non-embed control keeps help + wiki. A live `selectStation({line:'1',stopCode:49})` command drove the map to Capitol Hill and emitted the matching outbound `stationchange`.

Low risk: all new behavior is gated on `?embed`; the default app path is untouched (the extractions are pure refactors covered by the existing suite). No build/deploy/404 changes — the SPA 404 restore already preserves `?embed=1`.

> [!NOTE]
> **Follow-ups (out of scope):** a web-component / npm distributable, per-station rich previews, and an optional `INV-023 embed-param-parity` CI check keeping the docs' param list in sync with `embedConfig`.

---
_Generated with [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01MWw3z7TXqhyqeefuUnAed3

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWw3z7TXqhyqeefuUnAed3)_