### PR TITLE
chore: rename github URLs tommyroar → robogeosociety

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,6 @@
 name: Claude PR Assistant
 
-# Canonical @claude responder — source of truth: tommyroar/.github.
+# Canonical @claude responder — source of truth: robogeosociety/.github.
 # Synced into every owned repo by scripts/sync.sh. Also selectable one-click
 # from the Actions "New workflow" UI. Auth: CLAUDE_CODE_OAUTH_TOKEN (Max sub).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,5 +197,5 @@ PR descriptions follow the **newspaper / information-pyramid** format: one self-
 front page (kicker → headline → dek → masthead → why → what → mermaid flow → screens →
 verification → risk) that reads top-to-bottom on an iPad-mini portrait display (1–2 pages;
 up to 4 for very complex *code* changes). Rebuild from the **full** diff, never append.
-Full rules: <https://github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md>. CI validates
-the body via the `pr-newspaper` workflow (the reusable gate in `tommyroar/pr-newspaper`).
+Full rules: <https://github.com/robogeosociety/.github/blob/main/PR_FRAMEWORK.md>. CI validates
+the body via the `pr-newspaper` workflow (the reusable gate in `robogeosociety/pr-newspaper`).

--- a/infra/README.md
+++ b/infra/README.md
@@ -21,7 +21,7 @@ terraform apply
 
 - `CNAME @ → tommyroar.github.io` (proxied — CNAME flattening at the apex).
 - `CNAME www → walksheds.xyz` (proxied).
-- `CNAME wiki → tommyroar.github.io` (proxied) — the docs site at `wiki.walksheds.xyz`, served from the separate `tommyroar/walksheds-wiki` Pages site. The reader guide is at the root and the engineering codex at `wiki.walksheds.xyz/dev/` (a subpage of the same site).
+- `CNAME wiki → tommyroar.github.io` (proxied) — the docs site at `wiki.walksheds.xyz`, served from the separate `robogeosociety/walksheds-wiki` Pages site. The reader guide is at the root and the engineering codex at `wiki.walksheds.xyz/dev/` (a subpage of the same site).
 - Zone settings: `ssl = full`, `always_use_https = on`, `min_tls_version = 1.2`.
 
 Both DNS records are **proxied** (orange cloud). Cloudflare serves user-facing TLS via its Universal SSL cert; the `ssl = full` setting tells Cloudflare to re-encrypt to GitHub Pages' origin, which presents its own Let's Encrypt cert.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -32,7 +32,7 @@ resource "cloudflare_dns_record" "www" {
 }
 
 # wiki.walksheds.xyz — the reader-facing guide, served from a separate GitHub
-# Pages site (tommyroar/walksheds-wiki, since GitHub Pages allows only one custom
+# Pages site (robogeosociety/walksheds-wiki, since GitHub Pages allows only one custom
 # domain per repo). Same GH Pages edge + CNAME-flattening + `ssl = full` model
 # as the apex.
 resource "cloudflare_dns_record" "wiki" {

--- a/src/__tests__/POIPopupCard.test.jsx
+++ b/src/__tests__/POIPopupCard.test.jsx
@@ -154,7 +154,7 @@ describe('POIPopupCard report control', () => {
     expect(anchor.getAttribute('target')).toBe('_blank')
     expect(anchor.getAttribute('rel')).toContain('noopener')
     const url = new URL(anchor.getAttribute('href'))
-    expect(url.origin + url.pathname).toBe('https://github.com/tommyroar/walksheds/issues/new')
+    expect(url.origin + url.pathname).toBe('https://github.com/robogeosociety/walksheds/issues/new')
     expect(url.searchParams.get('labels')).toBe('poi-feedback')
     const body = url.searchParams.get('body')
     expect(body).toContain('Reason: duplicate')

--- a/src/__tests__/poiFeedback.test.js
+++ b/src/__tests__/poiFeedback.test.js
@@ -21,7 +21,7 @@ function bodyOf(url) {
 describe('buildFeedbackIssueUrl', () => {
   it('targets the walksheds repo new-issue endpoint with the poi-feedback label', () => {
     const url = new URL(buildFeedbackIssueUrl(POI, 'closed'))
-    expect(url.origin + url.pathname).toBe('https://github.com/tommyroar/walksheds/issues/new')
+    expect(url.origin + url.pathname).toBe('https://github.com/robogeosociety/walksheds/issues/new')
     expect(url.searchParams.get('labels')).toBe('poi-feedback')
   })
 

--- a/src/poiFeedback.js
+++ b/src/poiFeedback.js
@@ -6,7 +6,7 @@
 // DENY_OSM_IDS, rebuild tiles, close the issue). See docs/poi-feedback.md.
 
 // Matches public/CNAME / CLAUDE.md. Kept here so the URL builder is self-contained.
-const REPO = 'tommyroar/walksheds'
+const REPO = 'robogeosociety/walksheds'
 const FEEDBACK_LABEL = 'poi-feedback'
 
 // The three flag reasons surfaced as chips in the popup.

--- a/wiki/.github/workflows/deploy.yml
+++ b/wiki/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Guide to GitHub Pages
 
 # This workflow lives under wiki/ in the walksheds repo for review, but it is
 # inert there (GitHub only runs workflows at a repo root). It activates once the
-# contents of wiki/ become the root of the standalone tommyroar/walksheds-wiki
+# contents of wiki/ become the root of the standalone robogeosociety/walksheds-wiki
 # repo, which serves wiki.walksheds.xyz. It builds the reader guide at the root
 # and the dev codex (codex/) as a subpage at /dev/. See the codex deployment page.
 

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -8,7 +8,7 @@ Built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/). Tone
 
 ## Layout
 
-Authored under `wiki/` in the [`tommyroar/walksheds`](https://github.com/tommyroar/walksheds) repo for review, and published from the standalone `tommyroar/walksheds-wiki` repo. The deploy builds the guide to the site root and the codex to `/dev/`.
+Authored under `wiki/` in the [`robogeosociety/walksheds`](https://github.com/robogeosociety/walksheds) repo for review, and published from the standalone `robogeosociety/walksheds-wiki` repo. The deploy builds the guide to the site root and the codex to `/dev/`.
 
 ```
 mkdocs.yml                  guide site config, nav, theme (Link palette, 2 Line blue)

--- a/wiki/codex/docs/contributing.md
+++ b/wiki/codex/docs/contributing.md
@@ -44,4 +44,4 @@ See [Commands](commands.md) for the full list.
 
 ## Pull requests
 
-PR descriptions follow the **newspaper / information-pyramid** format — one self-contained front page that reads top to bottom: kicker, headline, dek, masthead, why, what, a mermaid flow, screens, verification, risk. Rebuild from the full diff rather than appending. CI validates the body via the `pr-newspaper` workflow. The full rules live in [`PR_FRAMEWORK.md`](https://github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md).
+PR descriptions follow the **newspaper / information-pyramid** format — one self-contained front page that reads top to bottom: kicker, headline, dek, masthead, why, what, a mermaid flow, screens, verification, risk. Rebuild from the full diff rather than appending. CI validates the body via the `pr-newspaper` workflow. The full rules live in [`PR_FRAMEWORK.md`](https://github.com/robogeosociety/.github/blob/main/PR_FRAMEWORK.md).

--- a/wiki/codex/docs/deployment.md
+++ b/wiki/codex/docs/deployment.md
@@ -51,7 +51,7 @@ terraform apply
 
 ## The docs site — one Pages site, two MkDocs projects
 
-Walksheds has one documentation site alongside the app: the reader **guide** at `wiki.walksheds.xyz`, with this **codex** served as a subpage at `wiki.walksheds.xyz/dev/`. Both are MkDocs Material projects authored in the main `walksheds` repo (`wiki/` and `wiki/codex/`) and published from a single Pages repo, `tommyroar/walksheds-wiki`.
+Walksheds has one documentation site alongside the app: the reader **guide** at `wiki.walksheds.xyz`, with this **codex** served as a subpage at `wiki.walksheds.xyz/dev/`. Both are MkDocs Material projects authored in the main `walksheds` repo (`wiki/` and `wiki/codex/`) and published from a single Pages repo, `robogeosociety/walksheds-wiki`.
 
 | Site | URL | Audience | Source dir |
 | --- | --- | --- | --- |
@@ -64,7 +64,7 @@ flowchart LR
     W[wiki/ — reader guide]
     C[wiki/codex/ — this codex]
   end
-  W --> WR[tommyroar/walksheds-wiki]
+  W --> WR[robogeosociety/walksheds-wiki]
   C --> WR
   WR -->|deploy: guide to /, codex to /dev/| WS[wiki.walksheds.xyz]
   TF[infra: wiki CNAME] --> CF[Cloudflare] --> WS

--- a/wiki/codex/mkdocs.yml
+++ b/wiki/codex/mkdocs.yml
@@ -2,8 +2,8 @@ site_name: Walksheds Codex
 site_url: https://wiki.walksheds.xyz/dev/
 site_description: The project codex for Walksheds — the Seattle Link light rail walkshed explorer. Architecture, data pipelines, invariants, design system, and operations.
 site_author: tommyroar
-repo_url: https://github.com/tommyroar/walksheds
-repo_name: tommyroar/walksheds
+repo_url: https://github.com/robogeosociety/walksheds
+repo_name: robogeosociety/walksheds
 edit_uri: edit/main/wiki/codex/docs/
 copyright: Transit data from Sound Transit, SDOT, OpenStreetMap, and Overture Maps.
 

--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -2,8 +2,8 @@ site_name: Walksheds Guide
 site_url: https://wiki.walksheds.xyz
 site_description: A plain-language guide to walksheds, walkability, and riding Seattle's Link light rail — how to use the walksheds.xyz map, what each station is near, and the story of the system.
 site_author: tommyroar
-repo_url: https://github.com/tommyroar/walksheds
-repo_name: tommyroar/walksheds
+repo_url: https://github.com/robogeosociety/walksheds
+repo_name: robogeosociety/walksheds
 edit_uri: edit/main/wiki/docs/
 copyright: A companion to walksheds.xyz. Transit data from Sound Transit, OpenStreetMap, and Overture Maps.
 


### PR DESCRIPTION
`fleet` — **ORG RENAME**

Mechanical URL sweep after the tommyroar → robogeosociety org migration — the POI-feedback issues-new owner (`src/poiFeedback.js` + its two tests), wiki/codex mkdocs `repo_url`/`repo_name` and doc repo refs, infra README/main.tf repo slugs, the CLAUDE.md PR-framework footer, and claude.yml/deploy.yml source-of-truth comments. Old github.com URLs redirect, so this is canonical cleanup, not a fix; the app itself is custom-domain (walksheds.xyz), so no Pages project URLs were involved.

## Verification
- `npm run test -- --run` — 390 passed (25 files), including the updated poiFeedback/POIPopupCard URL assertions
- `grep -rn tommyroar` — remaining hits: 7, each a protected form: `infra/variables.tf:16` `github_pages_user` default plus `infra/README.md:22,24` and `wiki/codex/docs/deployment.md:40,42` CNAME targets (live Cloudflare DNS target `tommyroar.github.io`, still valid for Pages custom-domain routing — flipping it is an infra decision applied on the mini against local state, deliberately left out of this sweep), and `wiki/mkdocs.yml:4` + `wiki/codex/mkdocs.yml:4` `site_author` (username, not a repo ref)
- CI: ci.yml + smoke.yml expected green

## Risk & rollout
- URL/doc-only except the `poiFeedback` REPO constant — POI feedback issues now file against `robogeosociety/walksheds` (the old owner redirects anyway); redirects cover the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
