### PR TITLE
Add scheduled monthly data-refresh CI/CD with Claude-authored review PR

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -1,0 +1,323 @@
+name: Monthly data refresh
+
+# Scheduled data-pipeline refresh: SDOT transit, Overpass OSM (POIs + station
+# exits), conditional Mapbox walksheds/Matrix, Overture release bump, refined
+# tile build, stats. Validates everything (invariants + JS suite + build)
+# BEFORE pushing a branch, then a second job has Claude author the
+# newspaper-format PR body for human review. New Sound Transit stations
+# detected in the SDOT feed are flagged and escalated as a @claude issue —
+# this workflow never edits data/process.py.
+#
+# Runs on the 26th monthly: Overture releases land mid-month (e.g.
+# 2026-04-15.0), so this leaves ~10 days of replication buffer while keeping
+# one refresh per calendar month. Ordering of the pipeline steps is
+# load-bearing — see CLAUDE.md "Automated monthly refresh".
+
+on:
+  schedule:
+    - cron: '0 14 26 * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Run the pipeline and validation but push nothing
+        type: boolean
+        default: false
+      skip_overture:
+        description: Skip the Overture release bump
+        type: boolean
+        default: false
+      force_walksheds:
+        description: Refresh Mapbox walksheds even without coordinate changes (invalidates the whole Matrix cache)
+        type: boolean
+        default: false
+      branch_suffix:
+        description: Branch name suffix, e.g. -test
+        type: string
+        default: ''
+
+concurrency:
+  group: data-refresh
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    outputs:
+      branch: ${{ steps.branch.outputs.branch }}
+      changed: ${{ steps.diff.outputs.changed }}
+      new_stations: ${{ steps.stations.outputs.new_stations }}
+      issue_url: ${{ steps.issue.outputs.url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v5
+
+      - name: System and Python deps
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq libcairo2
+          pip install --quiet duckdb cairosvg Pillow pytest
+      - run: npm install
+
+      - name: Branch name
+        id: branch
+        run: echo "branch=data-refresh/$(date -u +%Y-%m)${{ inputs.branch_suffix }}" >> "$GITHUB_OUTPUT"
+
+      # ---- 1. SDOT transit (stations + alignment + sprites) ----
+      - name: Refresh SDOT and reprocess
+        run: uv run data/refresh.py
+
+      - name: Detect station changes
+        id: stations
+        run: |
+          python3 data/detect_station_changes.py \
+            --github-output "$GITHUB_OUTPUT" \
+            --issue-body "$RUNNER_TEMP/station-issue.md"
+
+      - name: Station coordinates changed?
+        id: coords
+        run: |
+          if git diff --quiet HEAD -- public/all-stations.geojson; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            python3 - >> "$GITHUB_OUTPUT" <<'EOF'
+          import json, subprocess
+          old = json.loads(subprocess.run(
+              ["git", "show", "HEAD:public/all-stations.geojson"],
+              capture_output=True, text=True, check=True).stdout)
+          new = json.load(open("public/all-stations.geojson"))
+          coords = lambda fc: sorted(
+              (f["properties"]["name"], tuple(f["geometry"]["coordinates"]))
+              for f in fc["features"])
+          print(f"changed={'true' if coords(old) != coords(new) else 'false'}")
+          EOF
+          fi
+
+      # ---- 2. Overpass OSM dumps (retry: Overpass 429/504 is the likely flake) ----
+      - name: Refresh OSM POI dump
+        run: |
+          for i in 1 2 3; do
+            python3 data/pois/fetch_pois.py --refresh && break
+            [ "$i" = 3 ] && exit 1
+            sleep $((i * 120))
+          done
+      - name: Refresh station exits dump
+        run: |
+          for i in 1 2 3; do
+            python3 data/pois/fetch_station_exits.py --refresh && break
+            [ "$i" = 3 ] && exit 1
+            sleep $((i * 120))
+          done
+
+      # ---- 3. Mapbox walksheds — ONLY on coordinate changes. A refresh bumps
+      #         the walkshed version and invalidates the entire Matrix cache. ----
+      - name: Refresh walksheds (Isochrone)
+        if: steps.coords.outputs.changed == 'true' || inputs.force_walksheds
+        run: python3 data/pois/fetch_walksheds.py --refresh
+        env:
+          MAPBOX_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+
+      # ---- 4. Per-category build, then Matrix top-up (order matters: the
+      #         Matrix step reads public/pois/*.geojson which fetch_pois writes
+      #         and build_refined later deletes). ----
+      - name: Rebuild per-category POIs
+        run: python3 data/pois/fetch_pois.py
+      - name: Top up walking distances (Matrix, incremental)
+        run: python3 data/pois/fetch_walking_distances.py --refresh
+        env:
+          MAPBOX_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+
+      # ---- 5. Overture release bump (degrades to the current pin) + refined build ----
+      - name: Discover and apply latest Overture release
+        id: overture
+        if: ${{ !inputs.skip_overture }}
+        run: python3 data/pois/latest_overture_release.py --apply --github-output "$GITHUB_OUTPUT"
+      - name: Refined build (tiles + tag categories)
+        run: python3 data/pois/build_refined.py
+      - name: Rebuild stats
+        run: python3 data/pois/build_stats.py
+
+      # ---- 6. Full validation BEFORE anything is pushed ----
+      - name: Data invariants + processing tests
+        run: pytest data/pois/test_invariants.py data/test_process.py data/test_detect_station_changes.py -q
+      - run: npm run lint
+      - run: npm run test -- --run
+      - run: npm run build
+        env:
+          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+
+      # ---- 7. Summarize, commit, push ----
+      - name: Stage changes and build refresh summary
+        id: diff
+        run: |
+          git add -A
+          python3 - <<'EOF'
+          import json, os, subprocess
+          def sh(*args):
+              return subprocess.run(args, capture_output=True, text=True).stdout.strip()
+          old_stats = {}
+          raw = sh("git", "show", "HEAD:public/pois/stats.json")
+          if raw:
+              old_stats = json.loads(raw)
+          new_stats = json.load(open("public/pois/stats.json"))
+          summary = {
+              "month": os.environ.get("REFRESH_MONTH", ""),
+              "overture": {
+                  "previous": os.environ.get("OVERTURE_CURRENT", ""),
+                  "pinned": os.environ.get("OVERTURE_LATEST", ""),
+                  "bumped": os.environ.get("OVERTURE_BUMP", "") == "true",
+              },
+              "walksheds_refreshed": os.environ.get("COORDS_CHANGED", "") == "true"
+                  or os.environ.get("FORCE_WALKSHEDS", "") == "true",
+              "poi_count": {"previous": old_stats.get("pois"), "now": new_stats["pois"]},
+              "station_count": {"previous": old_stats.get("stations"), "now": new_stats["stations"]},
+              "station_changes": json.loads(os.environ.get("NEW_STATIONS", "[]")),
+              "diff_stat": sh("git", "diff", "--cached", "--stat"),
+          }
+          with open(os.path.join(os.environ["RUNNER_TEMP"], "refresh-summary.json"), "w") as f:
+              json.dump(summary, f, indent=2)
+          EOF
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          REFRESH_MONTH: ${{ steps.branch.outputs.branch }}
+          OVERTURE_CURRENT: ${{ steps.overture.outputs.current }}
+          OVERTURE_LATEST: ${{ steps.overture.outputs.latest }}
+          OVERTURE_BUMP: ${{ steps.overture.outputs.bump }}
+          COORDS_CHANGED: ${{ steps.coords.outputs.changed }}
+          FORCE_WALKSHEDS: ${{ inputs.force_walksheds }}
+          NEW_STATIONS: ${{ steps.stations.outputs.new_stations }}
+
+      - name: Commit and push refresh branch
+        if: steps.diff.outputs.changed == 'true' && !inputs.dry_run
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Monthly data refresh $(date -u +%Y-%m)" \
+                     -m "SDOT, Overpass, and Overture data refreshed by the scheduled data-refresh workflow. Details in the pull request."
+          # Lease against the branch's current remote tip (or its absence), so
+          # a same-month rerun updates the branch but a human's fixup commits
+          # pushed in the meantime make the push fail loudly instead of being
+          # clobbered.
+          branch="${{ steps.branch.outputs.branch }}"
+          git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch" 2>/dev/null || true
+          expected=$(git rev-parse --verify --quiet "refs/remotes/origin/$branch" || true)
+          git push --force-with-lease="refs/heads/$branch:$expected" origin "HEAD:refs/heads/$branch"
+
+      - name: Close superseded older refresh PRs
+        if: steps.diff.outputs.changed == 'true' && !inputs.dry_run
+        run: |
+          gh pr list --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("data-refresh/")) | select(.headRefName != "${{ steps.branch.outputs.branch }}") | .number' |
+          while read -r n; do
+            gh pr close "$n" --comment "Superseded by the $(date -u +%Y-%m) data refresh."
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # ---- 8. New-station escalation. Issues created with github.token do not
+      #         trigger claude.yml (anti-recursion); the body tells the reviewer
+      #         to comment "@claude proceed" — deliberately human-in-the-loop. ----
+      - name: Open station-change issue
+        id: issue
+        if: steps.stations.outputs.station_changes == 'true' && !inputs.dry_run
+        run: |
+          url=$(gh issue create \
+            --title "SDOT feed station changes detected by the $(date -u +%Y-%m) data refresh" \
+            --body-file "$RUNNER_TEMP/station-issue.md")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: refresh-summary
+          path: ${{ runner.temp }}/refresh-summary.json
+          if-no-files-found: ignore
+
+      - name: Surface failure as an issue
+        if: failure()
+        run: |
+          title="Data refresh failed for $(date -u +%Y-%m)"
+          existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+          body="The scheduled data refresh failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  pr:
+    needs: refresh
+    if: needs.refresh.outputs.changed == 'true' && !inputs.dry_run
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.refresh.outputs.branch }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: refresh-summary
+
+      # PR creation runs inside claude-code-action (Claude GitHub App token),
+      # so the resulting PR triggers ci.yml and the pr-newspaper gate normally
+      # (github.token-created PRs would not).
+      - name: Author the refresh PR (Claude, pinned to Sonnet 5)
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-5
+            --allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"
+          prompt: |
+            You are on branch ${{ needs.refresh.outputs.branch }} of the
+            walksheds repo, which contains this month's automated data refresh,
+            already committed and pushed. Do not modify, commit, or push any
+            files — your only job is the pull request itself.
+
+            1. Read refresh-summary.json in the workspace root, run
+               `git diff origin/main...HEAD --stat`, and read CLAUDE.md's
+               "Pull requests" section for the newspaper body format. No emoji
+               anywhere (INV-018).
+            2. If an open PR from this branch to main already exists
+               (`gh pr list --head <branch>`), rewrite its body with
+               `gh pr edit`; otherwise create it with `gh pr create --base main`.
+               Title: "Monthly data refresh <YYYY-MM from the branch name>".
+            3. The body must follow the newspaper format (kicker, headline,
+               dek, masthead, why, what, mermaid flow, verification, risk) and
+               summarize the refresh from refresh-summary.json: Overture
+               release change (or "unchanged"), OSM dump deltas, POI/station
+               count changes, whether walksheds were refreshed, and the diff
+               stat. Verification section: state that the full invariant suite,
+               JS tests, lint, and build all passed inside the refresh workflow
+               before the branch was pushed.
+            4. If refresh-summary.json lists station_changes entries, put a
+               prominent "NEW STATION DETECTED" section at the TOP of the body
+               linking ${{ needs.refresh.outputs.issue_url }} and stating that
+               this PR intentionally does NOT wire the station into
+               data/process.py (that follow-up happens via the linked issue).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ python3 data/pois/fetch_station_exits.py                 # Rebuild station-exits
 python3 data/pois/fetch_station_exits.py --refresh       # Refetch station entrances from Overpass, then rebuild
 python3 data/icons/fetch_app_icon.py                     # Rebuild iOS home-screen icons from the committed walksheds dump
 python3 data/pois/build_stats.py                         # Rebuild public/pois/stats.json (legend Statistics section; no network)
+python3 data/pois/latest_overture_release.py             # Report the newest Overture release vs the pinned one (--apply to pin it)
+python3 data/detect_station_changes.py                   # Diff the raw SDOT feed against the app's station set (new-station detection)
 ```
 
 ## Architecture
@@ -121,6 +123,19 @@ Two committed dumps power the "Nearest stations" section of POI popups:
 **Refresh order when POIs change:** `fetch_pois.py --refresh` → `fetch_walking_distances.py --refresh` (the latter re-fetches Matrix entries for any new POI ids inside a walkshed). `fetch_walksheds.py --refresh` is only needed when station coordinates change.
 
 **Mapbox token for refresh scripts:** set `MAPBOX_TOKEN` (or `MAPBOX_ACCESS_TOKEN`) in the environment. Public (`pk.`) and secret (`sk.`) tokens have identical capability for Isochrone + Matrix (both are read endpoints); the practical reason for a build-only token is URL restrictions — if the browser-side `VITE_MAPBOX_ACCESS_TOKEN` is restricted to `walksheds.xyz`, calls from a Python script will fail the referrer check. Easiest fix: add the build host's URL (or leave unrestricted) on that token, or mint a separate token for the scripts.
+
+### Automated monthly refresh (.github/workflows/data-refresh.yml)
+
+A scheduled workflow (26th monthly, ~10 days after Overture's mid-month release; also `workflow_dispatch` with `dry_run` / `skip_overture` / `force_walksheds` / `branch_suffix` inputs) refreshes the whole pipeline and opens a PR for human review on branch `data-refresh/YYYY-MM` (same-month reruns update the same branch; older open refresh PRs are closed as superseded). Step order is load-bearing:
+
+1. `data/refresh.py` (SDOT + reprocess) → `data/detect_station_changes.py` (new-station detection vs HEAD baseline) → geometry-only coordinate-change check.
+2. `fetch_pois.py --refresh` + `fetch_station_exits.py --refresh` (Overpass, with retries).
+3. `fetch_walksheds.py --refresh` **only if station coordinates changed** (or `force_walksheds`) — a walkshed version bump invalidates the entire Matrix cache, so it must never happen needlessly.
+4. `fetch_pois.py` (per-category build the Matrix step reads) → `fetch_walking_distances.py --refresh` (incremental top-up).
+5. `data/pois/latest_overture_release.py --apply` (anonymous S3 discovery; accepts a release only if its places theme exists on S3; degrades to the current pin on any failure) → `build_refined.py` → `build_stats.py`.
+6. Full validation (invariant suite, `data/test_process.py`, JS tests, lint, build) runs **before** anything is pushed — no partial state ever reaches the remote.
+
+The PR body is authored by a second job via `anthropics/claude-code-action@v1` pinned to `claude-sonnet-5` (newspaper format, passes the `pr-newspaper` gate; PR created under the Claude GitHub App token so ci.yml triggers normally). A detected new station is flagged prominently in the PR and escalated as a GitHub issue enumerating the hardcoded touch points (`LINE_*_ORDER`, `STOP_CODES`, `MISSING_STATIONS`, count assertions, sprites); the workflow itself never edits `data/process.py`, and the issue requires a human "@claude proceed" comment to start the follow-up (default-token issues do not trigger claude.yml).
 
 ### Station exits/entrances (OSM → public/station-exits.geojson)
 

--- a/data/detect_station_changes.py
+++ b/data/detect_station_changes.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Detect Sound Transit station changes in the freshly downloaded SDOT feed.
+
+Run right after data/refresh.py in the monthly data-refresh workflow. Applies
+the same filter process.py uses (STATUS == "Existing / Under Construction",
+Tacoma streetcar excluded, NAME_MAP renames) to the fresh raw feed, then diffs
+against the committed baseline: station names in HEAD's all-stations.geojson
+union process.py's hardcoded line orders. Diffing against HEAD (not the
+previous raw dump) makes the check self-healing across skipped months.
+
+Because process.py's station wiring is hardcoded (LINE_1_ORDER / LINE_2_ORDER,
+STOP_CODES, MISSING_STATIONS, SHARED_COUNT, the 38-count assertions), a new
+station needs human-judged code edits — this script only DETECTS and reports;
+it never edits process.py. Its output feeds the refresh PR body and, when
+non-empty, an escalation issue for the @claude responder.
+
+Usage:
+  python3 data/detect_station_changes.py \
+      [--raw data/raw/light-rail-stations.geojson] \
+      [--github-output "$GITHUB_OUTPUT"] [--issue-body PATH]
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, HERE)
+
+from process import LINE_1_ORDER, LINE_2_ORDER, MISSING_STATIONS, NAME_MAP, TACOMA_KW  # noqa: E402
+
+DEFAULT_RAW = os.path.join(HERE, "raw", "light-rail-stations.geojson")
+MISSING_NAMES = {name for name, _lng, _lat in MISSING_STATIONS}
+
+
+def sdot_station_names(raw):
+    """Station names in the feed after process.py's exact filter.
+
+    Mirrors process.py main(): STATUS gate, Tacoma keyword exclusion on the
+    NAME property (positionally the third value, as process.py reads it),
+    NAME_MAP renames.
+    """
+    names = set()
+    for feat in raw["features"]:
+        props = feat["properties"]
+        if props.get("STATUS") != "Existing / Under Construction":
+            continue
+        raw_name = list(props.values())[2]
+        if any(kw in raw_name for kw in TACOMA_KW):
+            continue
+        names.add(NAME_MAP.get(raw_name, raw_name))
+    return names
+
+
+def committed_station_names():
+    """Station names in all-stations.geojson at HEAD (pre-refresh baseline)."""
+    out = subprocess.run(
+        ["git", "show", "HEAD:public/all-stations.geojson"],
+        capture_output=True, text=True, check=True, cwd=ROOT,
+    ).stdout
+    return {f["properties"]["name"] for f in json.loads(out)["features"]}
+
+
+def diff_stations(sdot_names, committed_names):
+    """The change report. Baseline = committed stations union the hardcoded
+    orders, so a station already wired into process.py is never re-flagged."""
+    baseline = committed_names | set(LINE_1_ORDER) | set(LINE_2_ORDER)
+    return {
+        # In the feed as Existing, unknown to the app: a station opening.
+        "new_stations": sorted(sdot_names - baseline),
+        # Hardcoded-coordinate stations that now appear in the feed: they
+        # should graduate out of MISSING_STATIONS (real SDOT coordinates).
+        "graduated_missing": sorted(MISSING_NAMES & sdot_names),
+        # Committed stations gone from the feed, excluding the ones we
+        # expect to be absent (MISSING_STATIONS). Flag only, never auto-remove.
+        "removed_stations": sorted((committed_names - sdot_names) - MISSING_NAMES),
+    }
+
+
+def render_issue_body(report):
+    new = ", ".join(report["new_stations"]) or "none"
+    lines = [
+        "@claude The monthly data refresh detected Sound Transit station changes",
+        "in the SDOT feed that need hardcoded wiring in data/process.py. The",
+        "refresh PR intentionally does not make these code edits.",
+        "",
+        f"New stations (Existing / Under Construction, not in the app): {new}",
+    ]
+    if report["graduated_missing"]:
+        lines.append(
+            "Now in the SDOT feed (remove from MISSING_STATIONS, use real "
+            "coordinates): " + ", ".join(report["graduated_missing"]))
+    if report["removed_stations"]:
+        lines.append(
+            "Missing from the SDOT feed (investigate before removing anything): "
+            + ", ".join(report["removed_stations"]))
+    lines += [
+        "",
+        "Touch points for wiring a new station (open as a follow-up PR, do not",
+        "piggyback on the refresh PR):",
+        "- data/process.py: LINE_1_ORDER / LINE_2_ORDER insertion point,",
+        "  STOP_CODES entry (three-digit code reference in CLAUDE.md, Station",
+        "  Codes section), MISSING_STATIONS removal if applicable, SHARED_COUNT",
+        "  only if the shared trunk changes.",
+        "- data/test_process.py: the 38 / 13 shared / 13 line-1 / 12 line-2",
+        "  count assertions.",
+        "- data/pois/test_invariants.py + CLAUDE.md: INV-012's station count.",
+        "- Sprites: rerun data/process.py (INV-013 / INV-014).",
+        "- Downstream, in order: fetch_walksheds.py --refresh (new coordinates;",
+        "  bumps the walkshed version and correctly invalidates the whole",
+        "  Matrix cache), fetch_pois.py, fetch_walking_distances.py --refresh,",
+        "  build_refined.py, build_stats.py.",
+        "",
+        "This issue was opened by the data-refresh workflow with the default",
+        "Actions token, which does not trigger the @claude responder — comment",
+        "'@claude proceed' to start.",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Detect SDOT station changes")
+    ap.add_argument("--raw", default=DEFAULT_RAW, help="fresh raw SDOT stations GeoJSON")
+    ap.add_argument("--github-output", help="path to append GitHub Actions step outputs to")
+    ap.add_argument("--issue-body", help="write an escalation issue body here when changes exist")
+    args = ap.parse_args()
+
+    with open(args.raw) as f:
+        raw = json.load(f)
+    report = diff_stations(sdot_station_names(raw), committed_station_names())
+    changed = any(report.values())
+
+    print(json.dumps(report, indent=2))
+    if args.github_output:
+        with open(args.github_output, "a") as f:
+            f.write(f"new_stations={json.dumps(report['new_stations'])}\n")
+            f.write(f"station_changes={str(changed).lower()}\n")
+    if args.issue_body and changed:
+        with open(args.issue_body, "w") as f:
+            f.write(render_issue_body(report) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/pois/latest_overture_release.py
+++ b/data/pois/latest_overture_release.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Discover the newest Overture Maps release and (optionally) pin it.
+
+The Overture release pin is the RELEASE constant in fetch_overture.py —
+build_refined.py derives PLACES_GLOB from it and build_stats.py reads it
+textually — so rewriting that single constant propagates everywhere.
+
+Discovery lists the public overturemaps-us-west-2 bucket anonymously
+(S3 ListObjectsV2 with a delimiter, stdlib urllib — the same no-credential
+access path the DuckDB build query uses). A candidate release is accepted
+only if its places theme actually has objects on S3, so a just-announced
+but not-yet-replicated release can never be pinned. On any discovery
+failure the current pin is kept and the script exits 0 with bump=false —
+the monthly refresh workflow degrades on the Overture side, never aborts.
+
+Usage:
+  python3 data/pois/latest_overture_release.py               # report only
+  python3 data/pois/latest_overture_release.py --current     # print the pin
+  python3 data/pois/latest_overture_release.py --apply       # rewrite RELEASE
+  ... --github-output "$GITHUB_OUTPUT"   # write current/latest/bump outputs
+"""
+import argparse
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+from urllib.parse import quote
+from urllib.request import urlopen
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FETCH_OVERTURE = os.path.join(HERE, "fetch_overture.py")
+
+S3_ENDPOINT = "https://overturemaps-us-west-2.s3.us-west-2.amazonaws.com"
+S3_NS = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
+TIMEOUT = 30
+
+RELEASE_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}\.\d+$")
+# Same pin regex build_stats.py uses — keep the two in sync.
+PIN_RE = re.compile(r'^RELEASE = "([^"]+)"', re.M)
+
+
+def current_release():
+    with open(FETCH_OVERTURE) as f:
+        return PIN_RE.search(f.read()).group(1)
+
+
+def _s3_list(prefix, delimiter="/", max_keys=1000):
+    """One anonymous ListObjectsV2 page. Returns (common_prefixes, keys)."""
+    url = (f"{S3_ENDPOINT}/?list-type=2&max-keys={max_keys}"
+           f"&prefix={quote(prefix)}&delimiter={quote(delimiter)}")
+    with urlopen(url, timeout=TIMEOUT) as resp:
+        tree = ET.fromstring(resp.read())
+    prefixes = [e.text for e in tree.findall("s3:CommonPrefixes/s3:Prefix", S3_NS)]
+    keys = [e.text for e in tree.findall("s3:Contents/s3:Key", S3_NS)]
+    return prefixes, keys
+
+
+def _release_sort_key(release_id):
+    date, _, patch = release_id.partition(".")
+    return (date, int(patch))
+
+
+def list_releases():
+    """All release ids on the bucket, oldest to newest. One page suffices —
+    Overture ships monthly, so the release count stays far under 1000."""
+    prefixes, _ = _s3_list("release/")
+    ids = [p[len("release/"):].rstrip("/") for p in prefixes]
+    return sorted((r for r in ids if RELEASE_ID_RE.match(r)), key=_release_sort_key)
+
+
+def places_theme_exists(release_id):
+    """True if the release's places theme has at least one object on S3."""
+    _, keys = _s3_list(f"release/{release_id}/theme=places/type=place/",
+                       delimiter="", max_keys=1)
+    return bool(keys)
+
+
+def apply_release(release_id):
+    with open(FETCH_OVERTURE) as f:
+        src = f.read()
+    updated = PIN_RE.sub(f'RELEASE = "{release_id}"', src, count=1)
+    with open(FETCH_OVERTURE, "w") as f:
+        f.write(updated)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Discover/pin the latest Overture release")
+    ap.add_argument("--current", action="store_true", help="print the pinned release and exit")
+    ap.add_argument("--apply", action="store_true", help="rewrite RELEASE in fetch_overture.py")
+    ap.add_argument("--github-output", help="path to append GitHub Actions step outputs to")
+    args = ap.parse_args()
+
+    current = current_release()
+    if args.current:
+        print(current)
+        return
+
+    latest, note = None, ""
+    try:
+        releases = list_releases()
+        # Newest release whose places theme is actually queryable.
+        for candidate in reversed(releases):
+            if _release_sort_key(candidate) <= _release_sort_key(current):
+                break
+            if places_theme_exists(candidate):
+                latest = candidate
+                break
+            note = f"(newest listed release {candidate} has no places theme yet)"
+    except Exception as e:  # degrade: keep the pin, never fail the refresh
+        note = f"(discovery failed: {e})"
+
+    bump = latest is not None
+    if bump and args.apply:
+        apply_release(latest)
+
+    print(f"current={current} latest={latest or current} bump={str(bump).lower()} {note}".rstrip())
+    if args.github_output:
+        with open(args.github_output, "a") as f:
+            f.write(f"current={current}\nlatest={latest or current}\nbump={str(bump).lower()}\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/test_detect_station_changes.py
+++ b/data/test_detect_station_changes.py
@@ -1,0 +1,63 @@
+"""Tests for detect_station_changes.py (monthly refresh new-station detection)."""
+import os
+import sys
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+# detect_station_changes imports process.py, which imports cairosvg at module
+# level for sprite generation — skip where the cairo stack isn't installed
+# (same convention as INV-014 in data/pois/test_invariants.py).
+pytest.importorskip("cairosvg")
+pytest.importorskip("PIL")
+
+from detect_station_changes import diff_stations, sdot_station_names  # noqa: E402
+from process import LINE_1_ORDER, MISSING_STATIONS  # noqa: E402
+
+
+def _feat(name, status="Existing / Under Construction"):
+    # Property order mirrors the SDOT feed: NAME is the third value,
+    # which is how process.py (and the detector) reads it.
+    return {"type": "Feature",
+            "properties": {"OBJECTID_1": 1, "STATUS": status, "NAME": name},
+            "geometry": {"type": "Point", "coordinates": [-122.3, 47.6]}}
+
+
+def test_filter_mirrors_process():
+    raw = {"features": [
+        _feat("Northgate Station"),
+        _feat("NE 130th Station", status="Future"),          # status-filtered
+        _feat("Tacoma Dome Station"),                        # Tacoma-excluded
+        _feat("NE 145th Station"),                           # NAME_MAP renamed
+    ]}
+    names = sdot_station_names(raw)
+    assert names == {"Northgate Station", "Shoreline South/148th Station"}
+
+
+def test_new_station_detected():
+    committed = set(LINE_1_ORDER)
+    sdot = committed | {"NE 130th St Station"}
+    report = diff_stations(sdot, committed)
+    assert report["new_stations"] == ["NE 130th St Station"]
+
+
+def test_known_stations_not_flagged():
+    committed = set(LINE_1_ORDER)
+    report = diff_stations(set(committed), committed)
+    assert report["new_stations"] == []
+    assert report["removed_stations"] == []
+
+
+def test_graduated_missing_and_removed():
+    committed = set(LINE_1_ORDER)
+    missing_name = MISSING_STATIONS[0][0]           # hardcoded-coords station
+    assert missing_name in committed                 # sanity: it's on Line 1
+    sdot = {"Northgate Station", missing_name}
+    report = diff_stations(sdot, committed)
+    assert missing_name in report["graduated_missing"]
+    # Stations absent from the feed are flagged as removed, except the
+    # MISSING_STATIONS set, which is expected to be absent.
+    assert "Westlake Station" in report["removed_stations"]
+    assert missing_name not in report["removed_stations"]


### PR DESCRIPTION
PIPELINE · AUTOMATION

# The data pipeline goes on a monthly schedule

A scheduled workflow now refreshes every data source — SDOT transit, Overpass OSM, the Overture release pin, and (conditionally) Mapbox — validates the result against the full invariant suite, and opens a PR for human review. Nothing merges without a person; nothing pushes without green tests.

**By** claude/legend-statistics-section-cocc87 · **5 files, 1 workflow + 2 scripts + tests** · no new INV needed

## Why

Deployment and validation were CI/CD, but every data refresh was a human running scripts locally: the Overture pin was two releases stale (2026-04-15.0 vs 2026-06-17.0 live on S3), OSM drift accumulated silently, and a Sound Transit station opening would only be noticed by hand. The pipeline's committed-dump design makes automation safe: a workflow can regenerate everything and the append-only invariant suite (INV-001..023) plus the pr-newspaper gate already form the review scaffolding.

## What

- **`.github/workflows/data-refresh.yml`** (new) — two jobs. `refresh` (cron 26th monthly, ~10 days after Overture's mid-month release; `workflow_dispatch` with `dry_run` / `skip_overture` / `force_walksheds` / `branch_suffix`): SDOT refresh + station-change detection + geometry-only coordinate diff, Overpass refetches with retry/backoff, walkshed Isochrone refresh **only when coordinates changed** (a version bump invalidates the entire ~1,100-call Matrix cache), incremental Matrix top-up, Overture bump, refined tile build, stats — then the full validation suite (invariants, `test_process`, JS tests, lint, build) **before** any push. Branch `data-refresh/YYYY-MM`, force-with-lease with an explicit remote-tip lease (a human's fixup commits fail the push loudly rather than being clobbered); older open refresh PRs are closed as superseded. `pr` job: `anthropics/claude-code-action@v1` **pinned to `claude-sonnet-5`** authors the newspaper-format PR body from a generated `refresh-summary.json` and creates the PR under the Claude App token so ci.yml and the pr-newspaper gate trigger normally.
- **`data/pois/latest_overture_release.py`** (new) — anonymous S3 ListObjectsV2 discovery of the newest Overture release (stdlib urllib, no credentials), accepting a candidate only if its places theme actually has objects on S3; `--apply` rewrites the single `RELEASE` pin in `fetch_overture.py` that `build_refined.py` and `build_stats.py` both derive from. Any discovery failure degrades to the current pin (`bump=false`, exit 0) — the refresh never aborts on the Overture side.
- **`data/detect_station_changes.py`** (new) + **`data/test_detect_station_changes.py`** — applies process.py's exact station filter (STATUS, Tacoma exclusion, `NAME_MAP`) to the fresh SDOT feed and diffs against HEAD's `all-stations.geojson` union the hardcoded line orders: reports `new_stations`, `graduated_missing` (hardcoded-coordinate stations now in the feed), and `removed_stations`. On any change it renders an escalation issue body enumerating every hardcoded touch point (`LINE_*_ORDER`, `STOP_CODES`, `MISSING_STATIONS`, `SHARED_COUNT`, the 38/13/13/12 assertions, INV-012, sprites, then the walkshed → Matrix → refined rebuild chain). The workflow opens that issue; a human comments "@claude proceed" to start the follow-up — deliberately human-in-the-loop, and the refresh workflow itself never edits `process.py`.
- **`CLAUDE.md`** — new "Automated monthly refresh" subsection documenting the load-bearing step order and the conditional-walkshed rule, plus the two new commands.

## Flow

```mermaid
flowchart LR
  A[cron 26th monthly] --> R[refresh job]
  R --> S[SDOT + station-change detect]
  R --> O[Overpass OSM dumps]
  R --> M[Mapbox only if coords changed]
  R --> V[Overture S3 discovery + pin bump]
  V --> B[build_refined + build_stats]
  B --> T[invariants + JS tests + build]
  T -->|green| P[push data-refresh/YYYY-MM]
  P --> C[Claude Sonnet 5 authors newspaper PR]
  S -->|new station| I[escalation issue for @claude]
  C --> H[human review + merge]
```

## Verification

- `pytest data/pois/test_invariants.py data/test_process.py data/test_detect_station_changes.py` — **28 passed** (4 new detector tests: filter mirrors process.py, new-station detection, no false positives, graduated/removed handling).
- `data/pois/latest_overture_release.py` run live against S3: correctly reports `current=2026-04-15.0 latest=2026-06-17.0 bump=true` without applying.
- `data/detect_station_changes.py` run against the committed feed: correctly reports no changes.
- Workflow YAML parsed and both embedded Python heredocs syntax-checked; `npm run lint` clean.
- Not yet exercised end-to-end in Actions: after merge, run `workflow_dispatch` with `dry_run=true` first (validates runner deps, DuckDB S3 egress, and whether the Mapbox token's URL restriction blocks script calls), then a full rehearsal with `branch_suffix=-test`.

## Risk

Medium-low — the workflow is additive and cannot push anything unless the entire validation suite passes, so the worst credible failure is a red workflow run (surfaced via an auto-maintained failure issue). Known caveats: the Mapbox secret may be URL-restricted (first dry run will show it; mint an unrestricted build token if so), and the DuckDB S3 scan runtime on standard runners is unmeasured (90-minute budget; measure in the dry run). Monthly Mapbox spend is ~zero by design — full Isochrone/Matrix rebuilds happen only when station coordinates actually change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpGtiphfTL354Z6DXSFdTQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpGtiphfTL354Z6DXSFdTQ)_