### PR TITLE
feat(ci): the uptime check moves out of the house

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,10 +1,13 @@
 name: Live smoke
 
-# Probes the live site with Playwright. Its run conclusions + the github-pages
-# deployment_status events are ingested into InfluxDB by the host-side
-# walksheds-uptime collector (observability repo) and shown on the Grafana
-# uptime dashboard. schedule + deployment_status fire from the default branch
-# once merged; workflow_dispatch works on any branch.
+# Probes the live site with Playwright -- does the app actually render. This is
+# the functional check; `uptime.yml` is the cheap availability check that runs
+# far more often. Run conclusions are collected org-wide by the cicd-collector
+# Worker (robogeosociety/observability-config) into Analytics Engine, which also
+# posts red default-branch runs to Discord #dev; the old host-side
+# walksheds-uptime InfluxDB collector this used to feed is retired.
+# schedule + deployment_status fire from the default branch once merged;
+# workflow_dispatch works on any branch.
 on:
   schedule:
     - cron: '*/30 * * * *'   # periodic uptime probe

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,127 @@
+name: Uptime
+
+# Synthetic availability probe for the live site, run from a GitHub-hosted
+# runner (i.e. from outside the LAN, which is the point of an uptime check).
+#
+# This replaces the uptime half of the retired host-side `walksheds-uptime`
+# launchd collector on the Mac mini, which wrote to an InfluxDB that no longer
+# exists (robogeosociety/observability-config, retired in rgs#167 WS5). This
+# lane is alerting-only by design: a failed probe posts to Discord #dev and
+# turns the run red. No metrics history is kept.
+#
+# Deliberately separate from `smoke.yml`: that one is a heavyweight Playwright
+# job (checkout + npm install + chromium, ~45s) asserting the app renders
+# correctly. This one is a dependency-free curl that asks a narrower question --
+# is the origin serving at all -- so it can run far more often and cannot break
+# for reasons unrelated to the site.
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+# No checkout, so no contents access is needed. `actions: read` is only for the
+# alert-once gate, which reads this workflow's own previous run conclusion.
+permissions:
+  actions: read
+
+concurrency:
+  group: uptime
+  cancel-in-progress: false
+
+env:
+  TARGET_URL: https://walksheds.xyz/
+  ALERT_CHANNEL: dev
+
+jobs:
+  probe:
+    name: Probe walksheds.xyz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe the live site
+        id: probe
+        run: |
+          set -uo pipefail
+          up=0 code=000 ms=0
+          for attempt in 1 2 3; do
+            out=$(curl -sS -o /dev/null -m 20 \
+                    -w '%{http_code} %{time_total}' \
+                    -A 'walksheds-uptime (github-actions)' \
+                    "$TARGET_URL") || out="000 0"
+            code="${out% *}"
+            secs="${out#* }"
+            ms=$(awk -v s="$secs" 'BEGIN { printf "%.0f", s * 1000 }')
+            echo "attempt $attempt: status=$code latency=${ms}ms"
+            # Matches the retired collector's threshold: 2xx and 3xx are up.
+            if [ "$code" -ge 200 ] && [ "$code" -lt 400 ]; then
+              up=1
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then sleep 15; fi
+          done
+          {
+            echo "up=$up"
+            echo "status=$code"
+            echo "latency_ms=$ms"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check whether this outage was already announced
+        id: gate
+        if: steps.probe.outputs.up != '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          # Stateless alert-once gate: if the previous completed run of this
+          # workflow also failed, the outage has already been announced, so stay
+          # quiet until it recovers. Any error here falls through to "announce" --
+          # a duplicate alert is a far better failure mode than a silent outage.
+          prev=$(curl -sS --fail-with-body -m 20 \
+                   -H "authorization: Bearer $GH_TOKEN" \
+                   -H "accept: application/vnd.github+json" \
+                   "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/uptime.yml/runs?status=completed&per_page=1" \
+                 | jq -r '.workflow_runs[0].conclusion // "none"') || prev="unknown"
+          echo "previous completed run: $prev"
+          if [ "$prev" = "failure" ]; then
+            echo "announce=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "announce=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Alert Discord
+        if: steps.probe.outputs.up != '1' && steps.gate.outputs.announce == 'true'
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          STATUS: ${{ steps.probe.outputs.status }}
+        run: |
+          set -uo pipefail
+          api() { curl -sS --fail-with-body -m 20 \
+                    -H "authorization: Bot $DISCORD_BOT_TOKEN" "$@"; }
+
+          # Resolve #dev by name across the guilds the bot is in -- the same
+          # lookup the cicd-collector Worker uses, so no channel ID is hardcoded.
+          channel_id=""
+          for gid in $(api https://discord.com/api/v10/users/@me/guilds | jq -r '.[].id'); do
+            hit=$(api "https://discord.com/api/v10/guilds/$gid/channels" \
+                  | jq -r --arg n "$ALERT_CHANNEL" \
+                      'first(.[] | select(.type == 0 and .name == $n) | .id) // empty')
+            if [ -n "$hit" ]; then channel_id="$hit"; break; fi
+          done
+          if [ -z "$channel_id" ]; then
+            echo "::error::channel #${ALERT_CHANNEL} not found in any guild the bot is in"
+            exit 1
+          fi
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          text=$(printf '**walksheds.xyz is DOWN** -- HTTP %s after 3 attempts over ~30s.\nProbed from a GitHub-hosted runner. <%s>' \
+                   "$STATUS" "$run_url")
+          jq -n --arg c "$text" '{content: $c}' \
+            | api -X POST -H 'content-type: application/json' -d @- \
+                "https://discord.com/api/v10/channels/$channel_id/messages" > /dev/null
+          echo "alerted #${ALERT_CHANNEL}"
+
+      - name: Fail the run when the site is down
+        if: steps.probe.outputs.up != '1'
+        run: |
+          echo "::error::walksheds.xyz unreachable -- last status ${{ steps.probe.outputs.status }}"
+          exit 1


### PR DESCRIPTION
`CI` — **OPS DISPATCH**

# The uptime check moves out of the house

> _A probe that lived on a Mac mini, measuring the site from inside the same LAN, writing to a database that no longer exists. It is now ten lines of curl running from GitHub's network._

> [!NOTE]
> **ops/monitoring** · feat · risk: low · part of robogeosociety/robot-geographical-society#175

For months `walksheds.xyz` availability was measured by a launchd job on the Mac mini, every 120s, into a home InfluxDB. Two things were wrong. It probed from *inside* the LAN, a path no visitor takes. And rgs#167 WS5 retired that InfluxDB with the rest of the TIG stack — so it has been writing into a closed socket since 2026-07-21.

## What changed

- **`uptime.yml`** — new. A `*/10` cron plus `workflow_dispatch`. Three curl attempts 15s apart; 2xx or 3xx counts as up, matching the retired collector's threshold exactly. A failure posts to Discord `#dev` and turns the run red.
- **Channel by name, not by ID** — the lookup walks `/users/@me/guilds` then `/guilds/{id}/channels`, the same resolution the `cicd-collector` Worker uses. The org-level `DISCORD_BOT_TOKEN` is the only secret.
- **A stateless alert-once gate** — Actions has no KV, so the workflow reads its own previous completed run and stays quiet if that already failed.
- **`smoke.yml`** — comment only; its header still described the dead InfluxDB ingest. It stays a separate job on purpose: heavyweight Playwright (~45s) asking "does the app render", where this asks the cheaper "is the origin serving at all".

> _"Alerting only. The metrics history is not migrated — it is dropped, deliberately."_

## DEX was passed over, not overruled

observability-config#155 chose Cloudflare DEX for this probe. But DEX cannot poll the GitHub API for the CI-smoke and deploy signals, and an Actions probe already existed — extending it cost nothing. DEX stays on the shelf if hop-by-hop path telemetry is ever wanted.

## How it flows

```mermaid
flowchart TD
  cron["cron */10 + dispatch"] --> probe["curl walksheds.xyz<br/>3 attempts, 15s apart"]
  probe -->|2xx or 3xx| ok["run green, no message"]
  probe -->|otherwise| gate{"previous run<br/>already failed?"}
  gate -->|yes| quiet["stay quiet —<br/>already announced"]
  gate -->|no| alert["resolve #dev by name,<br/>POST message"]
  alert --> red["exit 1 — run red"]
  quiet --> red
```

## Verification

- Probe body extracted verbatim and run under `bash -e` (GitHub's default shell) against the live site (`up=1 status=200 249ms`), an unresolvable host (`up=0 status=000`) and a 404 path (`up=0 status=404`). All three wrote `$GITHUB_OUTPUT` and **exited 0** — so the alert step is reachable on a real outage, not skipped by a prematurely failing step.
- Every `jq` filter exercised against sample payloads: channel match, channel miss, previous-conclusion present, empty run list, message encoding. Both workflows parse as YAML.
- The Discord post cannot be proven pre-merge — `schedule` only fires from the default branch. The first scheduled run after merge is the live proof.

## Risk & rollout

- **Cadence regression, accepted** — 120s becomes ~10 min, and Actions cron is best-effort. Right trade for a static Pages site with zero hosted infrastructure.
- **The gate fails open** — any error reading the previous run announces anyway; a duplicate beats a silent outage.
- **Overlaps `cicd-collector`** (red default-branch runs already reach `#dev` within 5 min), so a down site may produce two messages — the same overlap observability-config#158 accepted against `github-heartbeat`.
- **Paired PR** robogeosociety/observability-config#167 deletes the collector, dashboard and roster rows. **Follow-up** robogeosociety/robot-geographical-society#176 removes the mini's plist — a human task, since `AGENTS.md` bars agents from mutating the live stack.
