### PR TITLE
Fix the monthly data refresh: declare cairosvg in refresh.py's script metadata

### DIFF
--- a/data/refresh.py
+++ b/data/refresh.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env -S uv run --script
+# cairosvg and pillow are process.py's dependencies, not this script's, but
+# download() runs process.py with sys.executable — the isolated interpreter uv
+# builds from the metadata below — so they have to be declared here too.
+# cairosvg also needs the system cairo library (libcairo2 on Ubuntu).
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["httpx"]
+# dependencies = ["cairosvg", "httpx", "pillow"]
 # ///
 """Refresh SDOT light rail data from Seattle ArcGIS and reprocess.
 


### PR DESCRIPTION
DATA PIPELINE / CI

# The monthly refresh never had cairosvg where it actually ran

**One line of script metadata puts process.py's dependencies in the interpreter that runs it, unbreaking the scheduled SDOT refresh.**

*One file changed, 5 insertions, 1 deletion. Fixes #90.*

## Why

The scheduled refresh fails at its first pipeline step, `Refresh SDOT and reprocess`, with `ModuleNotFoundError: No module named 'cairosvg'` raised from `data/process.py` ([run 30207080322](https://github.com/robogeosociety/walksheds/actions/runs/30207080322)), and the failure handler opens an issue every month.

Root cause: `data/refresh.py` is a PEP 723 inline-metadata script invoked as `uv run data/refresh.py`, so uv builds an isolated environment from its `# /// script` block, which declared only `httpx`. `download()` then runs `data/process.py` via `subprocess.check_call([sys.executable, ...])`, and `sys.executable` is that same isolated interpreter, not the runner's system python. The workflow's `pip install --quiet duckdb cairosvg Pillow pytest` installed the packages into the system python, which the uv environment never sees, so `process.py`'s top-level `import cairosvg` could not resolve. The apt `libcairo2` step and the pip install were both correct in intent; the dependencies simply landed in the wrong interpreter.

## What

`data/refresh.py` now declares the dependencies of the script it shells out to:

```toml
# dependencies = ["cairosvg", "httpx", "pillow"]
```

plus a comment recording why a script that does not import them has to declare them. Nothing else changed.

cairosvg is genuinely required by this path, not incidental: `process.py`'s `main()` unconditionally calls `generate_sprites()`, whose `svg_to_png()` is a `cairosvg.svg2png` wrapper, and the sprite sheets are committed outputs of the refresh. Making the import lazy or optional would only move the same failure to the same step.

The workflow is deliberately left alone. Its `libcairo2` apt step is still required, now by the uv environment as well as the system python, and its `pip install` is still required for the later `python3 data/pois/*.py` steps and for `pytest data/test_process.py`, which imports `process` under system python.

```mermaid
flowchart LR
    W["workflow step<br/>uv run data/refresh.py"] --> U["uv builds isolated env<br/>from PEP 723 metadata"]
    U --> R["refresh.py<br/>downloads SDOT GeoJSON"]
    R --> P["subprocess: sys.executable<br/>data/process.py"]
    P --> C{"import cairosvg"}
    C -->|"before: httpx only"| F["ModuleNotFoundError"]
    C -->|"after: cairosvg, httpx, pillow"| S["sprites and GeoJSON written"]
```

## Verification

Run locally on macOS with uv, using a pixi-provided cairo on `DYLD_FALLBACK_LIBRARY_PATH` to stand in for Ubuntu's `libcairo2`:

- `uv run data/refresh.py` — the exact failing step, end to end against the live Seattle ArcGIS endpoint. Downloaded 58 station and 292 alignment features, ran `process.py`, and generated 78 sprite icons plus both alignment GeoJSONs. This is the command that previously raised the `ModuleNotFoundError`.
- `pytest data/pois/test_invariants.py data/test_process.py data/test_detect_station_changes.py data/test_refresh.py` — 41 passed, 0 skipped. INV-014 (deterministic sprite manifest) executed rather than self-skipping, because cairosvg was importable.
- `ruff check data/refresh.py` — clean. `ruff format` reports pre-existing drift on this file at `HEAD` too, so formatting is left untouched to keep the diff minimal.
- The refresh reproduced every committed derived artifact except `public/icons/stations@2x.png`, which differs slightly under the local cairo build. All local run output was reverted; the branch contains only the `data/refresh.py` change.

Not run locally: the workflow beyond step 1. The Overpass, Mapbox Isochrone/Matrix, and Overture steps need network quotas and `MAPBOX_ACCESS_TOKEN`. They run under system `python3`, which the workflow's unchanged `pip install` already covers, and none were implicated in this failure.

## Risk

Low. One metadata line in one script, no behavior change to the pipeline. Resolving cairosvg and pillow slightly lengthens the uv environment build, and the refresh now depends on `libcairo2` being present for the uv environment as well, which the workflow's existing apt step already installs. The remaining failure mode is a genuinely missing system cairo, which would surface as the same clear import error rather than silent bad data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
