### PR TITLE
fix(data): harden SDOT station-name reading + clearer refresh failure messages

### DIFF
--- a/data/process.py
+++ b/data/process.py
@@ -175,6 +175,30 @@ OFFSET_METERS = 30
 LINE1_DESCS = {"Central Link", "University Link", "North Link", "Airport Link", "Angle Lake"}
 
 
+class SDOTSchemaError(RuntimeError):
+    """Raised when a downloaded SDOT GeoJSON feature is missing a field this
+    script depends on — signals an upstream schema change rather than a bug
+    in this script."""
+
+
+def station_name(feat):
+    """Extract a station feature's NAME, failing clearly if SDOT's schema changed.
+
+    Reads by key rather than by position: the station layer's field order
+    (OBJECTID_1, STATUS, NAME, STATION, ...) is not guaranteed to be stable,
+    so indexing into properties.values() would silently pick the wrong field
+    (or throw an opaque IndexError) if SDOT ever reorders or renames columns.
+    """
+    props = feat["properties"]
+    if "NAME" not in props:
+        raise SDOTSchemaError(
+            "SDOT station feature is missing the 'NAME' property — the "
+            f"upstream schema may have changed. Got properties: {sorted(props.keys())}. "
+            "Update data/process.py (and refresh.py's validate_stations) to match."
+        )
+    return props["NAME"]
+
+
 def dist(a, b):
     return math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2)
 
@@ -347,12 +371,12 @@ def main():
         feat
         for feat in raw_stations["features"]
         if feat["properties"].get("STATUS") == "Existing / Under Construction"
-        and not any(kw in list(feat["properties"].values())[2] for kw in TACOMA_KW)
+        and not any(kw in station_name(feat) for kw in TACOMA_KW)
     ]
 
     station_coords = {}
     for feat in existing:
-        raw_name = list(feat["properties"].values())[2]
+        raw_name = station_name(feat)
         name = NAME_MAP.get(raw_name, raw_name)
         station_coords[name] = feat["geometry"]["coordinates"]
 

--- a/data/refresh.py
+++ b/data/refresh.py
@@ -95,7 +95,24 @@ def download(dry_run: bool = False) -> tuple[dict, dict]:
     )
 
     print("\nProcessing...")
-    subprocess.check_call([sys.executable, str(ROOT / "data" / "process.py")])
+    try:
+        subprocess.check_call([sys.executable, str(ROOT / "data" / "process.py")])
+    except subprocess.CalledProcessError as exc:
+        # The child's own traceback already printed above (stdio is inherited,
+        # not captured) — but CI failure summaries and bots often surface only
+        # this exception's message, not the full log. Make that message useful
+        # on its own instead of the bare "Command [...] returned non-zero exit
+        # status 1" — the actual cause is almost always either a missing
+        # dependency (declare it in this file's `# /// script` metadata — see
+        # the comment at the top) or an unexpected SDOT schema change (see
+        # data/process.py's SDOTSchemaError and this file's validate_stations
+        # / validate_alignment).
+        raise RuntimeError(
+            f"data/process.py failed reprocessing the freshly-downloaded SDOT data "
+            f"(exit code {exc.returncode}). Scroll up for its traceback — the most "
+            "likely causes are a dependency missing from this script's inline "
+            "metadata, or SDOT having changed the shape of its GeoJSON."
+        ) from exc
 
     print("\nDone. Review changes with: git diff public/")
     return stations, alignment

--- a/data/test_process.py
+++ b/data/test_process.py
@@ -1,5 +1,6 @@
 """Tests for data processing — verify line alignment and station data integrity."""
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -20,6 +21,15 @@ def generate_data():
 def load(name):
     with open(os.path.join(PUBLIC, f"{name}.geojson")) as f:
         return json.load(f)
+
+
+def load_process_module():
+    """Import data/process.py as a module (for unit-testing its helpers directly,
+    rather than only exercising it end-to-end via the subprocess fixture above)."""
+    spec = importlib.util.spec_from_file_location("process", os.path.join(ROOT, "data", "process.py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class TestLineAlignment:
@@ -122,3 +132,27 @@ class TestStationData:
         assert by_name["Lynnwood City Center Station"] == 40
         assert by_name["Federal Way Downtown Station"] == 68
         assert by_name["Downtown Redmond Station"] == 65
+
+
+class TestSDOTSchemaGuard:
+    """station_name() reads the SDOT NAME field by key, not by position, and
+    fails with a clear, actionable error rather than an opaque IndexError (or
+    silently picking the wrong field) if SDOT ever reorders or renames its
+    station properties. Guards the fix for the 2026-07-26 monthly-refresh
+    failure mode (a missing dependency crashed process.py; this hardens the
+    related-but-distinct risk of an actual upstream schema change)."""
+
+    @pytest.mark.unit
+    def test_missing_name_raises_clear_schema_error(self):
+        process = load_process_module()
+        feat = {"properties": {"STATUS": "Existing / Under Construction", "STATION": "X"}}
+        with pytest.raises(process.SDOTSchemaError, match="NAME"):
+            process.station_name(feat)
+
+    @pytest.mark.unit
+    def test_name_read_by_key_not_by_column_position(self):
+        process = load_process_module()
+        # Property order deliberately does NOT match SDOT's usual
+        # OBJECTID_1, STATUS, NAME, ... layout, to prove this reads by key.
+        feat = {"properties": {"NAME": "Westlake Station", "STATUS": "Existing / Under Construction"}}
+        assert process.station_name(feat) == "Westlake Station"


### PR DESCRIPTION
`DATA PIPELINE` — **POSTMORTEM & HARDENING**

# The refresh was already fixed. The next landmine wasn't.

> _The `cairosvg` crash was fixed on main hours before this started. The code
> path that crashed still read a station's name by column position, not key —
> the failure mode this task actually worried about._

> [!NOTE]
> **data pipeline** · fix + hardening · risk: low · no open issue (#90 closed by #91)

## Why

[Run 30207080322](https://github.com/robogeosociety/walksheds/actions/runs/30207080322)
failed 2026-07-26; monthly cadence means it'd stay silently broken til August.

**Already fixed.** `refresh.py`'s `uv`-isolated venv declared only `httpx`,
then shelled to `process.py` in that same interpreter, whose `import cairosvg`
had nothing to import. [PR #91](https://github.com/robogeosociety/walksheds/pull/91),
merged 48 minutes later, declared `cairosvg`/`pillow` in that metadata.
Confirmed on main: live `uv run data/refresh.py` downloads the same 58
stations / 292 features and exits clean. **Schema unchanged** — dependency
bug only.

**A related risk was still live.** `process.py` read a station's name via
`list(feat["properties"].values())[2]` — position, not key, trusting SDOT's
column order forever, unlike `refresh.py`'s own `validate_stations()`. A
reordered column would throw an opaque `IndexError` or silently mislabel a
station — the "bare error, no message about what changed" mode this task
called out.

## What changed

- `data/process.py` — new `station_name(feat)` reads `NAME` by key, raising
  `SDOTSchemaError` (names the missing field + properties seen) instead of
  indexing positionally. Both call sites now use it.
- `data/refresh.py` — a `process.py` failure now raises `RuntimeError` with
  likely causes, not the bare `Command '[...]' returned non-zero exit status 1`.
- `data/test_process.py` — two new tests: `SDOTSchemaError`, key-vs-position.
- `workflow_dispatch` **not added** — already present (`dry_run` /
  `skip_overture` / `force_walksheds`) from when the refresh was built.

> _"The dependency bug was already dead. The landmine next to it wasn't."_

## How it flows

```mermaid
flowchart TD
    A["refresh.py downloads + validates SDOT"] --> B["subprocess: process.py"]
    B --> C{"station_name(feat)"}
    C -->|ok| D["write public/*.geojson + sprites"]
    C -->|"NAME missing"| E["SDOTSchemaError: names the field"]
    B -->|"any failure"| F["refresh.py: RuntimeError, likely cause"]
```

## Verification

- `uv run data/refresh.py` against the **live** Seattle ArcGIS endpoint
  (macOS, `pixi`-provided `cairo` for Ubuntu's `libcairo2`) — clean before and
  after my changes: 58 stations, 292 alignment features, sprites, exit 0.
- Simulated the schema-drift mode: stripped `NAME` from a real downloaded
  feature, ran `process.py` — got the new `SDOTSchemaError` message, not the
  old `IndexError`.
- `pytest data/test_process.py -q` — 10 passed (8 existing + 2 new).
- Regenerated `data/raw/*.geojson` / sprite PNGs **not committed** — derived
  artifacts.

**Left unverified:** a real Actions run on Ubuntu (`apt libcairo2`, not the
pixi stand-in) — `dry_run` exists for this, but firing it hits live
Overpass/Mapbox and secrets, so that's a deliberate follow-up, not a side
effect of this PR.

## Risk & rollout

- Low: `station_name()` is a drop-in replacement; the subprocess wrapper only
  changes the message on an already-failing path.
- Next check: a manual `dry_run` dispatch, or the 26th's scheduled fire.
