### PR TITLE
fix: the self-healing loop has a hole shaped like a hang

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -251,12 +251,21 @@ jobs:
           path: ${{ runner.temp }}/refresh-summary.json
           if-no-files-found: ignore
 
+      # `cancelled()` is load-bearing: a `timeout-minutes` kill concludes as CANCELLED, not
+      # FAILURE, so a plain `if: failure()` would stay silent on exactly the hang this job's
+      # 90-minute budget exists to catch. Safe to widen here because `cancel-in-progress` is
+      # false — no supersession can fire this spuriously.
       - name: Surface failure as an issue
-        if: failure()
+        if: failure() || cancelled()
         run: |
           title="Data refresh failed for $(date -u +%Y-%m)"
           existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
-          body="The scheduled data refresh failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "${{ job.status }}" = "cancelled" ]; then
+            what="was cancelled or hit its timeout"
+          else
+            what="failed"
+          fi
+          body="The scheduled data refresh $what: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"
           else


### PR DESCRIPTION
`OPS` — **CI DISPATCH**

# The self-healing loop has a hole shaped like a hang

> _`Surface failure as an issue` is guarded by `if: failure()`. A `timeout-minutes` kill concludes as **cancelled**, not failure — so the one job whose 90-minute budget exists to catch a hang would file nothing when it hangs._

> [!NOTE]
> .github/workflows · fix · low risk

This lane is genuinely self-healing: when the July refresh broke, the step below auto-filed issue #90, and PR #91 fixed it **48 minutes later**. That loop is why a monthly job with one shot a month recovered same-day.

It only fires on `failure()`.

## The gap

GitHub concludes a `timeout-minutes` kill as `cancelled`, never `failure`. `refresh` carries `timeout-minutes: 90`. So the failure mode the timeout is *for* — a hung subprocess against a live upstream — is precisely the one that files no issue, pings nobody, and waits a month for the next run.

Not hypothetical. Confirmed twice elsewhere in the fleet this week: `discobots/eval-weekly` killed at 45m11s against a 45-minute budget, and `obsidian-automations/deploy-exec` at 15m04s against 15. Both silent.

## The fix

```yaml
if: failure() || cancelled()
```

Safe to widen **here specifically** because this workflow sets `cancel-in-progress: false` — no superseded run can fire it spuriously, which is the usual reason not to reach for `cancelled()`. The issue body now distinguishes the two cases via `job.status`, so a timeout reads as a timeout rather than a generic failure.

## Verification

- [x] YAML parses
- [x] `cancel-in-progress: false` confirmed in this workflow — the spurious-trigger path does not exist
- [x] step's dedupe-or-comment logic untouched: still comments on an existing open issue for the month rather than filing duplicates

## Risk

Low. The blast radius is one more issue getting filed in a case that currently files none. The opposite error — staying quiet — has already cost this fleet two silent incidents.

Worth noting what this does **not** fix: 10 of 14 scheduled lanes across the org have no failure notification whatsoever, including all four `deploy-exec` lanes. This one at least had a guard to widen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
