### PR TITLE
ci: notify #dev when the live smoke lane fails or hangs

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,3 +39,18 @@ jobs:
         run: npx playwright test e2e/uptime.spec.js --project=chromium
         env:
           BASE_URL: https://walksheds.xyz
+
+  # `cancelled()` is deliberate, not just copy-pasted: this job has no explicit
+  # `timeout-minutes`, so it falls back to GitHub's 360-minute default, and a hang
+  # there (e.g. a stuck `npx playwright install --with-deps`) would report as
+  # cancelled, not failed. There's also no `concurrency` block on this workflow, so
+  # `cancelled()` can't fire from routine cancel-in-progress supersession -- the
+  # only realistic sources are a real hang or a human cancelling the run, both
+  # worth paging on.
+  notify-failure:
+    needs: [smoke]
+    if: failure() || cancelled()
+    uses: robogeosociety/.github/.github/workflows/notify-failure.yml@main
+    with:
+      lane: smoke
+    secrets: inherit


### PR DESCRIPTION
`CI` — **OPS DISPATCH**

# The smoke lane finally has a voice when the site goes dark

> _Live smoke has run every 30 minutes since launch without once being able to say it
> failed. This wires it into the org's new failure notifier._

> [!NOTE]
> **ci** · feat · risk: low · closes none

A 2026-07-30 org survey found 10 of 14 scheduled/dispatch lanes with no failure
notification — including this one. `robogeosociety/.github` PR #30 merged a reusable
`notify-failure.yml`. `smoke.yml` is this repo's last uncovered lane; `data-refresh.yml`
already has its own notifier (PR #96) and is untouched.

## What changed
- Added a `notify-failure` job, `needs: [smoke]`, `secrets: inherit` (org
  `NOTIFY_SECRET`, no new secret created).
- Guard: `if: failure() || cancelled()`.

> _"A `timeout-minutes` kill concludes as cancelled, not failed — a plain `failure()`
> guard stays silent on exactly the hangs worth paging on."_

## Why `cancelled()` is safe here
- **No `concurrency` block** on this workflow — `cancelled()` can't fire from
  `cancel-in-progress` supersession, the noise scenario the reusable workflow warns
  about.
- **No `timeout-minutes`** on the `smoke` job — it falls back to GitHub's 360-minute
  default, and a hang there still ends as `cancelled`, exactly what this guard exists
  to catch.
- Triggers are `schedule` (every 30 min), `deployment_status`, `workflow_dispatch` — but
  the notifier only posts on failure/cancellation, never on every run, so trigger
  frequency doesn't translate into notification noise.

## How it flows
```mermaid
flowchart TD
  A[schedule / deployment_status / workflow_dispatch] --> B[smoke job]
  B -->|pass| C[nothing happens]
  B -->|failure or cancelled| D[notify-failure reusable]
  D --> E[deploy-gate /notify]
  E --> F[#dev post]
```

## Verification
- `yaml.safe_load` on the edited file parses clean.
- Diffed the added block against `notify-failure.yml@main`'s published contract and
  against the sibling `failure() || cancelled()` reasoning already in `data-refresh.yml`
  (PR #96, bespoke notifier, not the reusable one).
- Not run end-to-end: this PR's own CI doesn't exercise `schedule`/`deployment_status`.

## Risk & rollout
- Additive job only; existing `smoke` job unchanged. No new secrets.
- `data-refresh.yml` intentionally untouched — already covered.
